### PR TITLE
feat(worker): phase B guardrails with audit and observability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Thumbs.db
 # Claude/OMC local session state
 .omc/
 plans/
+.gstack/

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ Thumbs.db
 .omc/
 plans/
 .gstack/
+.gitnexus/
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,54 @@ This repo's agent instructions live in `CLAUDE.md`.
 Before making changes:
 
 - Read `CLAUDE.md`
+- Read `CONTEXT.md`
+- Read the relevant docs in `docs/`
 - Read `docs/agents/issue-tracker.md`
 - Read `docs/agents/triage-labels.md`
 - Read `docs/agents/domain.md`
 
 Follow the project commands and architecture notes from `CLAUDE.md`.
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **meta-ads** (594 symbols, 1132 relationships, 49 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/meta-ads/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/meta-ads/clusters` | All functional areas |
+| `gitnexus://repo/meta-ads/processes` | All execution flows |
+| `gitnexus://repo/meta-ads/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,155 @@
+# Architecture
+
+Meta Ads Automation is split into a browser dashboard and a Cloudflare Worker backend.
+
+```text
+Browser dashboard
+  │
+  │ HTTPS /api/*
+  ▼
+Cloudflare Worker fetch()
+  ├─ Auth and mutation-origin guard
+  ├─ JSON API routes
+  ├─ Cloudflare KV for account-scoped config/log cache
+  ├─ Cloudflare D1 for audit history
+  └─ Meta Graph API v21.0
+
+Cloudflare Worker scheduled()
+  ├─ 30-minute cron
+  ├─ run lock in KV
+  ├─ rule evaluation from Meta campaign + insight data
+  ├─ dry-run/live action executor
+  ├─ D1 audit persistence
+  └─ KV action-log persistence
+```
+
+## Runtime surfaces
+
+### Frontend
+
+The frontend is a Vite, React, and TypeScript app in `frontend/`.
+
+Key files:
+
+- `frontend/src/main.tsx` mounts the React app.
+- `frontend/src/App.tsx` renders `Dashboard`.
+- `frontend/src/components/Dashboard.tsx` owns account selection, campaign polling, sorting, config editing, and dashboard rendering.
+- `frontend/src/lib/api.ts` provides `apiFetch()` and resolves `VITE_API_URL` with a local Worker fallback.
+- `frontend/src/types.ts` mirrors dashboard-facing backend response models.
+
+The dashboard first calls `/api/ad-accounts`, then requires the operator to choose an account before loading campaigns, config, and logs for that account.
+
+### Worker API
+
+The Worker entrypoint is `worker/src/index.ts`.
+
+`fetch()` handles:
+
+- CORS preflight.
+- `/api/*` authentication.
+- Mutation origin checks for config writes.
+- Route registration through `worker/src/router.ts`.
+- JSON API responses from `worker/src/api-handlers.ts`.
+
+### Worker cron
+
+`scheduled()` runs every 30 minutes from `worker/wrangler.jsonc`.
+
+The cron path:
+
+1. Loads config from KV, preferring `RULE_CONFIG::<META_ACCOUNT_ID>` and falling back to `RULE_CONFIG`.
+2. Skips when config is disabled.
+3. Acquires `AUTOMATION_RUN_LOCK` in KV for up to 25 minutes.
+4. Fetches active and paused campaigns for `META_ACCOUNT_ID`.
+5. Fetches account-level insights for today and for the trailing 3-day evidence window.
+6. Evaluates each campaign with strict `omni_purchase` evidence.
+7. Logs dry-run decisions or applies live pause/resume actions if gates allow.
+8. Persists run status, action logs, and campaign state into D1.
+9. Prepends KV action logs under `RULE_LOGS::<META_ACCOUNT_ID>`.
+
+## Persistence
+
+### KV
+
+KV is used for fast config/log storage and the run lock:
+
+- `RULE_CONFIG::<accountId>` — account-scoped normalized rule config.
+- `RULE_LOGS::<accountId>` — recent timeline entries capped to 1000 records.
+- `AUTOMATION_RUN_LOCK` — overlap guard for scheduled runs.
+
+The API path always expects `accountId` for account-scoped config, campaign list, and logs.
+
+### D1
+
+D1 stores audit records from `worker/migrations/0001_audit_schema.sql`:
+
+- `config_versions` — versioned config snapshots.
+- `automation_runs` — run lifecycle status and summaries.
+- `campaign_states` — last decision/action and `pausedByTool` provenance.
+- `action_logs` — structured dry-run, live, skipped, and failed decision records.
+
+## Rule model
+
+The source of truth for defaults is `RULE_CONFIG_DEFAULTS` in `worker/src/types.ts`.
+
+Defaults:
+
+- `enabled: true`
+- `dryRun: true`
+- `pauseThreshold: 170000`
+- `pauseThreshold2: 200000`
+- `resumeThreshold: 150000`
+- `cooldownHours: 24`
+- `maxActionsPerRun: 0`
+- `maxActionsPerDay: 0`
+- `allowlistCampaignIds: []`
+- `excludeCampaignIds: []`
+- `emergencyStop: false`
+- arming status starts as `not_armed`
+
+Decision inputs include today's spend, today's `omni_purchase`, trailing 3-day `omni_purchase`, dry-run state, action caps, allowlist/exclusion, emergency stop, arming state, and provenance.
+
+The evaluator fails closed when required `omni_purchase` evidence is missing. It returns `UNKNOWN_DATA` instead of treating missing purchases as zero.
+
+## Live-mode safety gates
+
+Live pause/resume actions are blocked unless all relevant gates pass:
+
+- `dryRun` is false.
+- Emergency stop is off.
+- The ad account is confirmed.
+- At least one campaign is allowlisted.
+- Per-run and per-day action caps are positive.
+- A recent dry-run review timestamp is present.
+- The campaign is not excluded.
+- Live campaigns are allowlisted.
+- Live resume has `pausedByTool` provenance in D1.
+
+The current code models cooldown and action caps in config/evidence, but full cap/cooldown enforcement should be verified before live rollout.
+
+## API response shape
+
+Worker responses use an envelope:
+
+```ts
+interface ApiSuccessResponse<T> {
+  success: true
+  data: T
+  error: null
+  message?: string
+  meta?: {
+    generatedAt: string
+    total?: number
+    version?: number | null
+    run?: RunHealthSummary | null
+  }
+}
+```
+
+Errors return `success: false`, `data`, a classified `error`, a user-facing `message`, and optional `meta`.
+
+## Deployment boundaries
+
+The frontend can be deployed independently from the Worker, but the backend auth contract must be settled first. The Worker accepts Cloudflare Access identity headers, `API_AUTH_TOKEN` bearer auth, or local bypass when `ALLOW_LOCAL_DEV=true` and the request is from localhost.
+
+For browser calls with bearer auth, confirm CORS headers before relying on `Authorization` from the frontend. The current frontend does not send bearer tokens.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,132 +2,16 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Agent skills
-
-### Issue tracker
-
-Issues are tracked in GitHub Issues for `monet88/meta-ads`. See `docs/agents/issue-tracker.md`.
-
-### Triage labels
-
-Triage uses the default five-label vocabulary: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, and `wontfix`. See `docs/agents/triage-labels.md`.
-
-### Domain docs
-
-Domain documentation uses a single-context layout with root `CONTEXT.md` and `docs/adr/`. See `docs/agents/domain.md`.
-
-## Skill workflow
-
-Use issue → plan → build → verify → ship as the default workflow.
-
-### 1. Shape unclear work
-
-- Use `/office-hours` when an idea is vague or needs sharper product framing.
-- Use `/to-prd` to turn conversation context into a PRD.
-- Use `/to-issues` to split a PRD or plan into GitHub issues.
-- Use `/triage` to classify issues with the labels in `docs/agents/triage-labels.md`.
-
-### 2. Plan before meaningful code
-
-- Use `/plan-eng-review` for backend rules, API changes, data flow, edge cases, and test strategy.
-- Use `/plan-design-review` for dashboard or other UI work.
-- Use `/plan-devex-review` for developer-facing API, CLI, SDK, docs, or onboarding changes.
-- Use `/autoplan` when the full review gauntlet should run with automatic decisions.
-- Skip planning only for small, low-risk fixes.
-
-### 3. Build or debug
-
-- Use `/tdd` for feature work and bug fixes where tests can lead.
-- Use `/diagnose` or `/investigate` for hard bugs, regressions, stack traces, and root-cause analysis.
-- Use `/design-shotgun` to explore UI variants before implementation.
-- Use `/design-html` to turn an approved UI direction into production HTML/CSS.
-- Use `/freeze` or `/guard` when edits must stay inside a safe scope.
-
-### 4. Verify
-
-- Use `/health` for lint/build/check aggregation and quality scoring.
-- Use `/qa` for frontend test-fix-verify loops.
-- Use `/qa-only` when only a bug report is wanted.
-- Use `/browse` or `/gstack` to dogfood UI flows in a browser.
-- Use `/benchmark` for page speed, Core Web Vitals, or bundle checks.
-- Use `/cso` or `/security-review` for security-sensitive changes.
-- Browser-test frontend changes before reporting completion.
-
-### 5. Review before shipping
-
-- Use `/simplify` after code works to reduce complexity in changed files.
-- Use `/review` for pre-landing diff review.
-- Use `/caveman-review` when terse actionable review comments are preferred.
-- Use `/codex review` or `/codex challenge` for an independent second opinion.
-- Fix review findings, then rerun `/health`.
-
-### 6. Ship and follow up
-
-- Use `/ship` to prepare version/changelog/commit/push/PR flow.
-- Use `/land-and-deploy` to merge, deploy, and verify production.
-- Use `/canary` to monitor a deployment after it lands.
-- Use `/document-release` to sync docs after shipping.
-
-### 7. Save and restore context
-
-- Use `/context-save` before stopping or switching machines.
-- Use `/context-restore` to resume previous work.
-- Use `/learn` to review or prune accumulated project learnings.
-- Use `/grill-with-docs` when domain language or architecture decisions should update `CONTEXT.md` or ADRs.
-
-### Repo-specific defaults
-
-- Frontend dashboard changes: `/plan-design-review` → `/tdd` or implementation → `/qa` → `/review` → `/health`.
-- Worker rule/API changes: `/plan-eng-review` → `/tdd` → `/security-review` → `/review` → `/health`.
-- Deploy, CORS, and env issues: `/diagnose` → `/health` → `/canary` when deployed.
-- Small fixes under 30 minutes: implement directly, then run `/health`.
-
 ## Project shape
 
-This repository contains two separate npm projects and no root `package.json`:
+This repository has a root `package.json` for shared tooling plus two app packages:
 
 - `frontend/` — Vite + React + TypeScript dashboard.
 - `worker/` — Cloudflare Workers TypeScript backend.
+- `docs/` — API, operations, security, ADR, and agent workflow docs.
 - `plans/` — implementation plan documents for the Meta Ads Automation System.
 
-Run commands from the relevant subdirectory.
-
-## Commands
-
-### Frontend (`frontend/`)
-
-```bash
-npm install
-npm run dev
-npm run build
-npm run lint
-npm run preview
-```
-
-- `npm run dev` starts Vite.
-- `npm run build` runs `tsc -b` then `vite build`.
-- `npm run lint` runs ESLint across the frontend.
-- There is no configured frontend test runner or single-test command in `frontend/package.json`.
-
-### Worker (`worker/`)
-
-```bash
-npm install
-npm run dev
-npx wrangler deploy
-```
-
-- `npm run dev` runs `wrangler dev` against `worker/src/index.ts` through `wrangler.jsonc`.
-- `npx wrangler deploy` deploys the Worker using `wrangler.jsonc`.
-- `npm test` is currently a placeholder that exits with `Error: no test specified`; do not use it as a real test signal.
-- There is no configured worker single-test command.
-
-### Local full-stack flow
-
-1. In `worker/`, create local secrets/vars for `META_ACCESS_TOKEN`, `META_ACCOUNT_ID`, and `CONFIG_KV` binding as required by Wrangler.
-2. Start backend: `cd worker && npm run dev` (default local Worker URL is `http://localhost:8787`).
-3. Start frontend: `cd frontend && npm run dev`.
-4. Frontend API base comes from `VITE_API_URL`; when unset it falls back to `http://localhost:8787`.
+Run app commands from the relevant subdirectory. The root package currently has no app scripts.
 
 ## Backend architecture
 
@@ -136,42 +20,64 @@ Cloudflare Worker entrypoint: `worker/src/index.ts`.
 The default export implements both Worker surfaces:
 
 - `scheduled()` runs the automation every 30 minutes, configured in `worker/wrangler.jsonc` as `*/30 * * * *`.
-- `fetch()` serves JSON API routes under `/api/*` and applies CORS.
+- `fetch()` serves JSON API routes under `/api/*`, applies auth/origin checks, and applies CORS.
 
 Key backend files:
 
-- `worker/src/index.ts` wires scheduled execution, config loading, action logging, and API routes.
-- `worker/src/auto-rule-engine.ts` evaluates campaign spend/purchase rules and calls pause/resume actions.
-- `worker/src/meta-api-client.ts` wraps Meta Graph API v21.0 campaign, insight, pause, and resume calls.
-- `worker/src/api-handlers.ts` implements HTTP handlers for campaigns, insights, config, logs, and health.
+- `worker/src/index.ts` wires scheduled execution, config loading, auth/origin guards, action logging, D1 audit persistence, and API routes.
+- `worker/src/auto-rule-engine.ts` evaluates campaign spend/purchase rules and executes dry-run/live pause/resume decisions.
+- `worker/src/meta-api-client.ts` wraps Meta Graph API v21.0 ad account, campaign, insight, pause, and resume calls.
+- `worker/src/api-handlers.ts` implements HTTP handlers for ad accounts, campaigns, insights, config, logs, and health.
 - `worker/src/router.ts` is a small regex path router for `GET` and `PUT` routes.
-- `worker/src/cors.ts` derives CORS headers from `FRONTEND_URL`, falling back to `*`.
-- `worker/src/types.ts` defines shared Worker env/config/action types.
+- `worker/src/cors.ts` derives CORS headers from request origin and `FRONTEND_URL`.
+- `worker/src/types.ts` defines shared Worker env/config/action/audit/API types and `RULE_CONFIG_DEFAULTS`.
+- `worker/migrations/0001_audit_schema.sql` defines D1 audit tables.
 
 Backend data/config flow:
 
-- Required env bindings: `META_ACCESS_TOKEN`, `META_ACCOUNT_ID`, `CONFIG_KV`.
-- `FRONTEND_URL` is configured in `wrangler.jsonc` for CORS.
-- Rule config is stored in KV key `RULE_CONFIG`; defaults are `pauseThreshold: 170000`, `resumeThreshold: 150000`, `enabled: true`.
-- Rule actions are prepended to KV key `RULE_LOGS` and capped to the latest 1000 entries.
-- Campaigns are fetched from `act_${META_ACCOUNT_ID}/campaigns` with effective statuses `ACTIVE` and `PAUSED`.
-- Insights use `date_preset=today` and fields `spend,actions`.
+- Required env bindings: `META_ACCESS_TOKEN`, `META_ACCOUNT_ID`, `CONFIG_KV`, `AUDIT_DB`.
+- `FRONTEND_URL` is configured in `wrangler.jsonc` for deployed dashboard CORS and config mutation origin checks.
+- Optional env: `API_AUTH_TOKEN` for bearer API access and `ALLOW_LOCAL_DEV=true` for localhost bypass.
+- Rule config is stored in account-scoped KV key `RULE_CONFIG::<accountId>`.
+- Rule logs are stored in account-scoped KV key `RULE_LOGS::<accountId>` and capped to the latest 1000 entries.
+- Scheduled-run overlap is guarded by KV key `AUTOMATION_RUN_LOCK`.
+- D1 stores `config_versions`, `automation_runs`, `campaign_states`, and `action_logs`.
+- API campaign/config/log routes require `accountId` query parameter and normalize optional `act_` prefix.
+
+Default rule config comes from `RULE_CONFIG_DEFAULTS` in `worker/src/types.ts`:
+
+- `enabled: true`
+- `dryRun: true`
+- `pauseThreshold: 170000`
+- `pauseThreshold2: 200000`
+- `resumeThreshold: 150000`
+- `cooldownHours: 24`
+- `maxActionsPerRun: 0`
+- `maxActionsPerDay: 0`
+- `allowlistCampaignIds: []`
+- `excludeCampaignIds: []`
+- `emergencyStop: false`
+- arming starts as `not_armed`
 
 Rule behavior in current code:
 
-- Pause an `ACTIVE` campaign when today's spend is above `pauseThreshold` and purchase count is `0`.
-- Resume a `PAUSED` campaign when today's spend is below `resumeThreshold` and purchase count is greater than `0`.
-- `extractPurchaseCount()` currently checks `omni_purchase` first, then falls back to `purchase`.
+- Purchase evidence is strict `omni_purchase`; missing required purchase evidence returns `UNKNOWN_DATA` instead of assuming zero.
+- Dry-run mode logs `WOULD_PAUSE` / `WOULD_RESUME` without mutating Meta campaigns.
+- Pause an `ACTIVE` campaign when today's spend is above `pauseThreshold` and both today and trailing 3-day `omni_purchase` counts are `0`.
+- Pause an `ACTIVE` campaign when today's spend is above `pauseThreshold2` and both today and trailing 3-day `omni_purchase` counts are fewer than `2`.
+- Resume a `PAUSED` campaign when today's spend is below `resumeThreshold` and today's `omni_purchase` count is greater than `0`.
+- Live mode is blocked by arming requirements, emergency stop, allowlist/caps, and resume provenance checks.
 
 API routes registered in `worker/src/index.ts`:
 
 | Method | Path | Handler |
 | --- | --- | --- |
-| `GET` | `/api/campaigns` | list campaigns enriched with today's insights |
+| `GET` | `/api/ad-accounts` | list Meta ad accounts visible to the token |
+| `GET` | `/api/campaigns?accountId=...` | list campaigns enriched with insights, decisions, blockers, warnings, and errors |
 | `GET` | `/api/campaigns/:id/insights` | get raw insight payload for one campaign |
-| `GET` | `/api/config` | read rule config from KV or defaults |
-| `PUT` | `/api/config` | validate and write rule config to KV |
-| `GET` | `/api/logs` | read action logs from KV |
+| `GET` | `/api/config?accountId=...` | read normalized account-scoped rule config |
+| `PUT` | `/api/config?accountId=...` | validate, version, gate, persist, and audit rule config |
+| `GET` | `/api/logs?accountId=...` | read account-scoped action logs from KV |
 | `GET` | `/api/health` | validate Meta token through Graph API `/me` |
 
 ## Frontend architecture
@@ -180,29 +86,40 @@ Frontend entrypoint: `frontend/src/main.tsx`; `frontend/src/App.tsx` renders `Da
 
 Key frontend files:
 
-- `frontend/src/components/Dashboard.tsx` owns dashboard state, polling, config editing, and campaign table rendering.
-- `frontend/src/api/client.ts` defines `apiFetch()` and resolves API base from `VITE_API_URL` or `http://localhost:8787`.
-- `frontend/src/types.ts` defines dashboard-facing rule, action, insight, and campaign types.
+- `frontend/src/components/Dashboard.tsx` owns ad account selection, dashboard state, polling, config editing, sorting, and campaign table rendering.
+- `frontend/src/lib/api.ts` defines `apiFetch()` and resolves API base from `VITE_API_URL` or `http://localhost:8787`.
+- `frontend/src/types.ts` defines dashboard-facing ad account, rule, action, insight, decision, and campaign types.
 - `frontend/src/components/ui/*` contains shadcn-style UI primitives.
 - `frontend/src/lib/utils.ts` supports UI utility composition.
 
 Frontend behavior:
 
-- On mount, dashboard calls `/api/campaigns`, `/api/config`, and `/api/health` in parallel.
-- Dashboard refreshes data every 60 seconds.
-- Rule changes are saved with `PUT /api/config`.
+- On mount, dashboard calls `/api/ad-accounts` and `/api/health` in parallel.
+- Dashboard requires account selection before loading `/api/campaigns`, `/api/config`, and `/api/logs` with `accountId`.
+- Dashboard refreshes selected-account data every 60 seconds.
+- Rule changes are saved with `PUT /api/config?accountId=...`.
 - UI uses the `@/*` alias configured in both `vite.config.ts` and `tsconfig*.json`.
 - shadcn metadata lives in `frontend/components.json`; Tailwind config is `frontend/tailwind.config.js`.
 
 ## Current codebase notes
 
-These are existing repository facts worth checking before frontend work:
+These are existing repository facts worth checking before frontend or live-rollout work:
 
-- `Dashboard.tsx` imports `apiFetch` from `@/lib/api`, but the existing client file is `frontend/src/api/client.ts`.
-- `Dashboard.tsx` imports `CampaignEnriched`, but `frontend/src/types.ts` does not export that name.
-- `Dashboard.tsx` imports icons from `lucide-react`, but `frontend/package.json` does not list `lucide-react`.
-- `tailwind.config.js` has `content: []`, so Tailwind will not scan source files until content globs are added.
-- Worker plan docs say to use only `omni_purchase`; current worker code falls back to `purchase` after `omni_purchase`.
+- `Dashboard.tsx` still computes action hints locally for display; future UI work should render backend decision/evidence/blocker fields directly.
+- The Worker can accept bearer auth, but the current frontend does not send bearer tokens and CORS does not allow the `Authorization` header yet.
+- Full browser QA is still needed for account selection, auth failure, config save, version conflict, blocked live mode, unknown data, and responsive states.
+- Full cooldown and action-cap enforcement should be verified before live mode.
+
+## Documentation
+
+- Root context: `CONTEXT.md`.
+- Project overview: `README.md`.
+- Architecture: `ARCHITECTURE.md`.
+- Contributor workflow: `CONTRIBUTING.md`.
+- API reference: `docs/API.md`.
+- Operations runbook: `docs/OPERATIONS.md`.
+- Security posture: `docs/SECURITY.md`.
+- ADRs: `docs/adr/`.
 
 ## Planning docs
 
@@ -211,26 +128,9 @@ Primary plan: `plans/260501-1630-meta-ads-automation/plan.md`.
 Important plan facts:
 
 - Intended architecture is Vercel-hosted Vite/React frontend plus Cloudflare Workers backend.
-- Backend phases are marked completed in the plan; frontend and deploy validation are pending.
-- Success criteria include 30-minute cron, no duplicate purchase counting, real-time campaign list, KV-backed threshold updates, working CORS, and deployment to Cloudflare Workers/Vercel.
+- Backend safety sprint work added auth/origin guards, dry-run/live state, D1 audit schema, strict `omni_purchase`, run locks, provenance checks, and worker tests.
+- Frontend and deployed Cloudflare/Vercel validation still need browser and environment verification before production use.
 
-## Skill routing
-
-When the user's request matches an available skill, invoke it via the Skill tool. When in doubt, invoke the skill.
-
-Key routing rules:
-- Product ideas/brainstorming → invoke /office-hours
-- Strategy/scope → invoke /plan-ceo-review
-- Architecture → invoke /plan-eng-review
-- Design system/plan review → invoke /design-consultation or /plan-design-review
-- Full review pipeline → invoke /autoplan
-- Bugs/errors → invoke /investigate
-- QA/testing site behavior → invoke /qa or /qa-only
-- Code review/diff check → invoke /review
-- Visual polish → invoke /design-review
-- Ship/deploy/PR → invoke /ship or /land-and-deploy
-- Save progress → invoke /context-save
-- Resume context → invoke /context-restore
 
 ## GBrain Configuration (configured by /setup-gbrain)
 - Engine: postgres
@@ -239,3 +139,47 @@ Key routing rules:
 - MCP registered: yes
 - Memory sync: artifacts-only
 - Current repo policy: read-write
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **meta-ads** (594 symbols, 1132 relationships, 49 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/meta-ads/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/meta-ads/clusters` | All functional areas |
+| `gitnexus://repo/meta-ads/processes` | All execution flows |
+| `gitnexus://repo/meta-ads/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,3 +231,11 @@ Key routing rules:
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
+
+## GBrain Configuration (configured by /setup-gbrain)
+- Engine: postgres
+- Config file: ~/.gbrain/config.json (mode 0600)
+- Setup date: 2026-05-02
+- MCP registered: yes
+- Memory sync: artifacts-only
+- Current repo policy: read-write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,3 +213,21 @@ Important plan facts:
 - Intended architecture is Vercel-hosted Vite/React frontend plus Cloudflare Workers backend.
 - Backend phases are marked completed in the plan; frontend and deploy validation are pending.
 - Success criteria include 30-minute cron, no duplicate purchase counting, real-time campaign list, KV-backed threshold updates, working CORS, and deployment to Cloudflare Workers/Vercel.
+
+## Skill routing
+
+When the user's request matches an available skill, invoke it via the Skill tool. When in doubt, invoke the skill.
+
+Key routing rules:
+- Product ideas/brainstorming → invoke /office-hours
+- Strategy/scope → invoke /plan-ceo-review
+- Architecture → invoke /plan-eng-review
+- Design system/plan review → invoke /design-consultation or /plan-design-review
+- Full review pipeline → invoke /autoplan
+- Bugs/errors → invoke /investigate
+- QA/testing site behavior → invoke /qa or /qa-only
+- Code review/diff check → invoke /review
+- Visual polish → invoke /design-review
+- Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Save progress → invoke /context-save
+- Resume context → invoke /context-restore

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,166 @@
+# CONTEXT.md
+
+## Product context
+
+Meta Ads Automation is a dashboard and automation worker for monitoring Meta ad campaigns and applying simple spend/purchase guardrails.
+
+The system is intended to help an operator:
+
+- See current campaign status and today's spend/purchase signals.
+- Configure pause/resume thresholds without redeploying code.
+- Let a scheduled Worker pause overspending campaigns with no purchases.
+- Resume paused campaigns when spend is below the resume threshold and purchases are present.
+- Review automation actions through a KV-backed log.
+
+## Repository shape
+
+This repo has a root `package.json` for shared tooling, plus two app packages:
+
+- `frontend/` — Vite, React, TypeScript dashboard.
+- `worker/` — Cloudflare Workers TypeScript backend.
+- `docs/` — API, operations, security, ADR, and agent workflow docs.
+- `plans/` — implementation planning documents.
+
+Run app commands from the relevant subdirectory.
+
+## Runtime architecture
+
+The frontend is a Vercel-targeted Vite app that calls the Worker JSON API under `/api/*`.
+
+The Worker has two surfaces:
+
+- `fetch()` handles API routes and CORS.
+- `scheduled()` runs the automation cron every 30 minutes.
+
+The Worker talks to:
+
+- Meta Graph API for campaigns, insights, token health, pause, and resume actions.
+- Cloudflare KV for account-scoped rule configuration, recent automation logs, and run locks.
+- Cloudflare D1 for config versions, automation runs, campaign states, and action logs.
+
+## Backend source of truth
+
+Worker entrypoint: `worker/src/index.ts`.
+
+Important backend modules:
+
+- `worker/src/api-handlers.ts` — HTTP handlers for ad accounts, campaigns, insights, config, logs, and health.
+- `worker/src/auto-rule-engine.ts` — scheduled rule evaluation and pause/resume decisions.
+- `worker/src/meta-api-client.ts` — Meta Graph API wrapper.
+- `worker/src/router.ts` — route matching for `GET` and `PUT` routes.
+- `worker/src/cors.ts` — CORS header derivation from `FRONTEND_URL`.
+- `worker/src/types.ts` — shared Worker types.
+
+Required bindings and environment:
+
+- `META_ACCESS_TOKEN`
+- `META_ACCOUNT_ID`
+- `CONFIG_KV`
+- `AUDIT_DB`
+- `FRONTEND_URL`
+
+Optional env/bindings:
+
+- `API_AUTH_TOKEN`
+- `ALLOW_LOCAL_DEV`
+
+KV keys:
+
+- `RULE_CONFIG::<accountId>` — stores account-scoped threshold and safety configuration.
+- `RULE_LOGS::<accountId>` — stores recent account-scoped automation action logs, capped to the latest 1000 entries.
+- `AUTOMATION_RUN_LOCK` — prevents overlapping scheduled automation runs.
+
+Default rule configuration:
+
+- `pauseThreshold: 170000`
+- `pauseThreshold2: 200000`
+- `resumeThreshold: 150000`
+- `enabled: true`
+- `dryRun: true`
+- `cooldownHours: 24`
+- `maxActionsPerRun: 0`
+- `maxActionsPerDay: 0`
+- `emergencyStop: false`
+- arming starts as `not_armed` with account confirmation and recent dry-run review required before live mode.
+
+Current rule behavior:
+
+- Treat `omni_purchase` as the only purchase metric for trusted automation decisions.
+- Return `UNKNOWN_DATA` instead of assuming zero purchases when required `omni_purchase` evidence is missing.
+- In dry-run mode, log `WOULD_PAUSE` / `WOULD_RESUME` decisions without mutating Meta campaigns.
+- Pause an `ACTIVE` campaign when today's spend is above `pauseThreshold` and both today's and trailing 3-day `omni_purchase` counts are `0`.
+- Pause an `ACTIVE` campaign when today's spend is above `pauseThreshold2` and both today's and trailing 3-day `omni_purchase` counts are fewer than `2`.
+- Resume a `PAUSED` campaign when today's spend is below `resumeThreshold` and today's `omni_purchase` count is greater than `0`.
+- Block live mode unless arming requirements pass, and block live resume unless D1 provenance shows the campaign was paused by this tool.
+
+## Frontend source of truth
+
+Frontend entrypoint: `frontend/src/main.tsx`.
+
+Important frontend modules:
+
+- `frontend/src/App.tsx` — renders the dashboard.
+- `frontend/src/components/Dashboard.tsx` — owns account selection, dashboard state, polling, config editing, and campaign table rendering.
+- `frontend/src/lib/api.ts` — API client and base URL resolution.
+- `frontend/src/types.ts` — dashboard-facing types.
+- `frontend/src/components/ui/*` — UI primitives.
+
+Frontend behavior:
+
+- On mount, loads ad accounts and health in parallel.
+- Requires an account selection before loading campaigns, config, and logs.
+- Refreshes selected-account data every 60 seconds.
+- Saves threshold changes with `PUT /api/config?accountId=...`.
+- Uses `VITE_API_URL` when present, otherwise defaults to `http://localhost:8787`.
+
+## API surface
+
+Registered Worker routes:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/ad-accounts` | List Meta ad accounts visible to the configured token. |
+| `GET` | `/api/campaigns?accountId=...` | List campaigns enriched with insights, decisions, blockers, warnings, and errors. |
+| `GET` | `/api/campaigns/:id/insights` | Return raw insight payload for one campaign. |
+| `GET` | `/api/config?accountId=...` | Read normalized account-scoped rule configuration. |
+| `PUT` | `/api/config?accountId=...` | Validate, version, gate, persist, and audit account-scoped rule configuration. |
+| `GET` | `/api/logs?accountId=...` | Read account-scoped action logs from KV. |
+| `GET` | `/api/health` | Validate Meta token through Graph API `/me`. |
+
+## Data semantics
+
+Campaigns are fetched from the account campaigns endpoint. Dashboard API routes use the selected `accountId`; scheduled automation uses `META_ACCOUNT_ID`.
+
+Insights include spend and Meta action counts. Trusted automation decisions require `omni_purchase` evidence for today and, for pause decisions, the trailing 3-day evidence window.
+
+Purchase counting should avoid duplicate counting across Meta action types. Current code treats `omni_purchase` as the only purchase metric and fails closed when it is missing.
+
+Amounts are threshold-like values used by the rule engine and UI. Keep frontend display formatting separate from backend rule comparisons.
+
+## Operational expectations
+
+- Worker cron should remain every 30 minutes unless a plan or issue explicitly changes it.
+- Config changes should be persisted in account-scoped KV and audited in D1, not hardcoded into frontend state.
+- CORS should be driven by `FRONTEND_URL` for deployed environments.
+- Keep deployed `/api/*` behind Cloudflare Access or a verified bearer-token flow.
+- Keep live automation in dry-run until arming blockers are cleared and recent dry-run evidence is reviewed.
+- Automation logs should preserve enough detail for an operator to understand what action was taken and why.
+
+## Current project status
+
+The branch now includes account-scoped dashboard/API work, strict `omni_purchase` handling, dry-run/live gate fields, D1 audit schema, and worker tests. Frontend browser QA and deployed Cloudflare/Vercel validation remain areas to verify before treating the system as production-ready.
+
+Known areas to check before frontend or rollout work:
+
+- Render backend decision/evidence/blocker fields directly instead of local action hints.
+- Verify frontend auth behavior for deployed API access.
+- Verify browser states for account selection, config save, version conflict, blocked live mode, unknown data, and auth failure.
+- Verify full cooldown/action-cap enforcement before live mode.
+
+## Working conventions
+
+- Keep backend and frontend commands scoped to their subdirectories.
+- Prefer small, issue-sized vertical slices.
+- Use GitHub Issues for tracking and the default labels: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`.
+- Store future durable architectural decisions in `docs/adr/`.
+- Do not commit, push, create PRs, or deploy without an explicit request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,113 @@
+# Contributing
+
+This repo contains two app packages. Work from the package directory you are changing.
+
+## Prerequisites
+
+- Node.js and npm.
+- A Meta access token that can read ad accounts, campaigns, insights, and update campaigns when live mode is intentionally enabled.
+- Cloudflare account access for Worker, KV, D1, and secrets work.
+- `gh` CLI for GitHub Issues and PR workflow.
+
+## Install
+
+```bash
+cd worker
+npm install
+
+cd ../frontend
+npm install
+```
+
+The root `package.json` has a Wrangler devDependency, but it has no app scripts. Use `worker/` and `frontend/` for normal development.
+
+## Local environment
+
+Create `worker/.dev.vars` for local Worker development:
+
+```bash
+META_ACCESS_TOKEN=<meta-token>
+META_ACCOUNT_ID=<default-account-id-without-act-prefix>
+FRONTEND_URL=http://localhost:5173
+ALLOW_LOCAL_DEV=true
+```
+
+Optional local-only values:
+
+```bash
+API_AUTH_TOKEN=<local-api-token>
+```
+
+Create `frontend/.env.local` only if the Worker is not running at `http://localhost:8787`:
+
+```bash
+VITE_API_URL=http://localhost:8787
+```
+
+Do not put secrets in `frontend/.env.local`. Vite exposes `VITE_` variables to client code.
+
+## Local smoke test
+
+Terminal 1:
+
+```bash
+cd worker
+npm run dev
+```
+
+Terminal 2:
+
+```bash
+cd frontend
+npm run dev
+```
+
+Then open the Vite dev server, confirm the API health badge, choose an ad account, and verify campaigns/config load for the selected account.
+
+## Test and build
+
+Worker:
+
+```bash
+cd worker
+npm test
+```
+
+Frontend:
+
+```bash
+cd frontend
+npm run lint
+npm run build
+```
+
+The Worker test suite uses `worker/vitest.config.ts`, `cloudflare:test`, and D1 migrations from `worker/test/d1-migrations.ts`.
+
+## Development workflow
+
+1. Start from a GitHub issue or create one if the work is not tracked.
+2. Read [CONTEXT.md](CONTEXT.md) and the relevant docs in [docs/](docs/).
+3. Keep changes small and vertical.
+4. For backend behavior, update or add Worker tests first when practical.
+5. For frontend behavior, run lint/build and browser-test the dashboard before claiming completion.
+6. Do not commit, push, create PRs, or deploy unless explicitly asked.
+
+## Documentation expectations
+
+Update docs when behavior changes:
+
+- API contract changes → [docs/API.md](docs/API.md).
+- Runtime/data-flow changes → [ARCHITECTURE.md](ARCHITECTURE.md).
+- Deploy, secrets, D1, KV, or runbook changes → [docs/OPERATIONS.md](docs/OPERATIONS.md).
+- Auth, origin, access, secrets, or live-action safety changes → [docs/SECURITY.md](docs/SECURITY.md).
+- Durable design decisions → new ADR in `docs/adr/`.
+
+## Issue tracker
+
+GitHub Issues are the source of truth for planned work. Use the labels documented in [docs/agents/triage-labels.md](docs/agents/triage-labels.md):
+
+- `needs-triage`
+- `needs-info`
+- `ready-for-agent`
+- `ready-for-human`
+- `wontfix`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,111 @@
+# Meta Ads Automation
+
+Dashboard and Cloudflare Worker automation for monitoring Meta ad campaigns, reviewing rule decisions, and safely pausing or resuming campaigns from spend and purchase evidence.
+
+## What this system does
+
+- Lists Meta ad accounts available to the configured token.
+- Lets an operator choose an ad account before loading campaigns and account-scoped rules.
+- Shows active and paused campaigns with today's spend, `omni_purchase` counts, decision state, blockers, warnings, and errors.
+- Stores rule configuration per ad account in Cloudflare KV.
+- Runs a scheduled Worker every 30 minutes for the configured `META_ACCOUNT_ID`.
+- Defaults automation to dry-run mode and blocks live mutations until arming requirements pass.
+- Persists audit data in D1 for config versions, automation runs, campaign states, and action logs.
+
+## Repository layout
+
+```text
+.
+├── frontend/              # Vite + React + TypeScript dashboard
+├── worker/                # Cloudflare Worker API, cron, tests, and D1 migrations
+├── docs/                  # API, operations, security, ADR, and agent workflow docs
+├── plans/                 # Planning artifacts, ignored for new local changes
+├── AGENTS.md              # Agent entrypoint that points to CLAUDE.md and docs/agents
+├── CLAUDE.md              # Claude Code project instructions
+├── CONTEXT.md             # Domain context and project vocabulary
+└── TODOS.md               # Deferred work that should stay visible
+```
+
+There is a root `package.json`, but app commands live in `frontend/` and `worker/`.
+
+## Quick start
+
+Install dependencies in each app package:
+
+```bash
+cd worker
+npm install
+
+cd ../frontend
+npm install
+```
+
+Create local Worker secrets in `worker/.dev.vars`:
+
+```bash
+META_ACCESS_TOKEN=<meta-token>
+META_ACCOUNT_ID=<default-account-id-without-act-prefix>
+FRONTEND_URL=http://localhost:5173
+ALLOW_LOCAL_DEV=true
+```
+
+Start the Worker API:
+
+```bash
+cd worker
+npm run dev
+```
+
+Start the dashboard in another terminal:
+
+```bash
+cd frontend
+npm run dev
+```
+
+For the dashboard, set `frontend/.env.local` only when the Worker is not at the default local URL:
+
+```bash
+VITE_API_URL=http://localhost:8787
+```
+
+Only variables prefixed with `VITE_` are exposed to Vite client code.
+
+## Verification commands
+
+```bash
+cd worker
+npm test
+
+cd ../frontend
+npm run lint
+npm run build
+```
+
+The Worker test suite uses `@cloudflare/vitest-pool-workers` and applies D1 migrations from `worker/migrations/` during test setup.
+
+## Documentation map
+
+- [CONTEXT.md](CONTEXT.md) — product context, domain vocabulary, and current project facts.
+- [ARCHITECTURE.md](ARCHITECTURE.md) — runtime architecture, data flow, and safety gates.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — setup, local smoke test, workflow, and testing expectations.
+- [docs/API.md](docs/API.md) — Worker API routes, auth, request shapes, and response envelopes.
+- [docs/OPERATIONS.md](docs/OPERATIONS.md) — secrets, D1/KV operations, deploy checklist, and incident runbooks.
+- [docs/SECURITY.md](docs/SECURITY.md) — auth, origin checks, secrets, audit posture, and known security gaps.
+- [docs/adr/README.md](docs/adr/README.md) — ADR format and storage location.
+- [docs/agents/](docs/agents/) — issue tracker, triage label, and domain-doc instructions for agent workflows.
+- [frontend/README.md](frontend/README.md) — dashboard-specific development notes.
+- [TODOS.md](TODOS.md) — deferred post-safety-sprint work.
+
+## Deployment shape
+
+- Frontend: Vite app intended for Vercel or another static host.
+- Backend: Cloudflare Worker with `fetch()` API routes and `scheduled()` cron.
+- Persistence: Cloudflare KV for account-scoped config/log cache and D1 for audit records.
+- External API: Meta Graph API v21.0.
+
+Before any live deployment, confirm the deployed auth path. The current Worker accepts Cloudflare Access identity headers or `Authorization: Bearer <API_AUTH_TOKEN>`, while the frontend does not currently inject bearer tokens.
+
+## Current status
+
+The branch contains account-scoped dashboard/API work, stricter `omni_purchase` handling, dry-run/live gate fields, D1 audit schema, and worker tests. Frontend browser QA and deployed Cloudflare/Vercel validation still need to be run before calling the system production-ready.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,41 @@
+# TODOs
+
+## Expose meta-ads API through MCP tools after Safety Sprint
+
+**What:** Expose read-only and tightly controlled mutation MCP tools over the secured meta-ads API.
+
+**Why:** Unlock an AI-native ad ops loop where agents can inspect campaigns, read action history, propose safer rules, and monitor outcomes after the trust layer exists.
+
+**Pros:**
+- Agents can reason from campaign state, config versions, D1 audit logs, and recent automation outcomes.
+- Read-only tools can help debugging and reporting without granting mutation power.
+- Controlled write tools can later support approval-based rule changes with full audit.
+
+**Cons:**
+- Write tools could amplify bad automation if auth, permissions, and audit are weak.
+- Requires strict tool permission design, rate limits, and provenance in logs.
+- Adds another API surface that must be tested and documented.
+
+**Context:** Current Safety Sprint explicitly defers MCP because the existing API lacks sufficient auth, logs, action provenance, and tests. Revisit once Cloudflare Access, D1 audit, dry-run, action caps, and backend decision models are stable.
+
+**Depends on / blocked by:** Cloudflare Access same-origin auth, D1 audit tables, config versions, action caps, dry-run mode, rule engine tests, and documented API contracts.
+
+## Add external notifications for automation actions and failures
+
+**What:** Add Slack, Telegram, email, or generic webhook notifications for live actions, dry-run candidates, failed runs, Meta API errors, emergency stop changes, and action-cap hits.
+
+**Why:** Dashboard activity logs only help when the operator is looking. Notifications make failed or dangerous automation visible quickly.
+
+**Pros:**
+- Operator learns when the bot acted, skipped, or failed without polling the dashboard.
+- Failed cron/rate-limit/token issues become visible before spend risk compounds.
+- Notification payloads can reuse D1 action/run log records.
+
+**Cons:**
+- Requires webhook secrets, retry policy, delivery failure handling, and noise controls.
+- Bad notification design can create alert fatigue.
+- Adds integration surface outside the core Worker/Dashboard loop.
+
+**Context:** Safety Sprint includes dashboard activity and run status. External notifications should come after run/action/error taxonomy is stable so alerts are meaningful and not noisy.
+
+**Depends on / blocked by:** D1 action logs, automation run status, error classification, dry-run/live state, and action-cap tracking.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,177 @@
+# API Reference
+
+The Cloudflare Worker serves JSON routes under `/api/*`.
+
+Base URL:
+
+- Local: `http://localhost:8787`
+- Deployed: the Worker URL or the same-origin route configured for the dashboard
+
+## Auth
+
+All `/api/*` routes except `OPTIONS` require one of:
+
+- local dev bypass: localhost request plus `ALLOW_LOCAL_DEV=true`
+- `Authorization: Bearer <API_AUTH_TOKEN>`
+- `CF-Access-Jwt-Assertion` from Cloudflare Access
+
+Config writes also require an allowed origin or referer:
+
+- localhost when `ALLOW_LOCAL_DEV=true`
+- `FRONTEND_URL` origin in deployed environments
+
+The Worker currently allows `Content-Type` in CORS preflight. If the browser frontend needs bearer auth, update and verify CORS for the `Authorization` header first.
+
+## Response envelope
+
+Success:
+
+```json
+{
+  "success": true,
+  "data": {},
+  "error": null,
+  "message": "Optional message",
+  "meta": {
+    "generatedAt": "2026-05-02T00:00:00.000Z",
+    "total": 1,
+    "version": 1
+  }
+}
+```
+
+Error:
+
+```json
+{
+  "success": false,
+  "data": null,
+  "error": {
+    "category": "validation",
+    "code": "INVALID_CONFIG",
+    "message": "Config validation failed",
+    "retryable": false,
+    "details": []
+  },
+  "message": "Config validation failed",
+  "meta": {
+    "generatedAt": "2026-05-02T00:00:00.000Z"
+  }
+}
+```
+
+## Routes
+
+| Method | Path | Query | Purpose |
+| --- | --- | --- | --- |
+| `GET` | `/api/ad-accounts` | none | List Meta ad accounts available to the token. |
+| `GET` | `/api/campaigns` | `accountId` required | List account campaigns with insights, decision, evidence, blockers, warnings, and errors. |
+| `GET` | `/api/campaigns/:id/insights` | none | Return today's raw Meta insights payload for a campaign. |
+| `GET` | `/api/config` | `accountId` required | Read normalized rule config for an account. |
+| `PUT` | `/api/config` | `accountId` required | Validate, version, persist, and audit config for an account. |
+| `GET` | `/api/logs` | `accountId` required | Read recent account-scoped activity timeline entries. |
+| `GET` | `/api/health` | none | Validate the Meta token through Graph API `/me`. |
+
+Use `accountId` with or without the `act_` prefix. The backend normalizes it before reading account-scoped KV keys.
+
+## GET /api/ad-accounts
+
+Returns the token's Meta ad accounts.
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "act_123",
+      "account_id": "123",
+      "name": "Main account",
+      "account_status": 1
+    }
+  ],
+  "error": null,
+  "meta": {
+    "generatedAt": "2026-05-02T00:00:00.000Z",
+    "total": 1
+  }
+}
+```
+
+## GET /api/campaigns?accountId=123
+
+Returns campaign rows shaped for the dashboard.
+
+Important fields:
+
+- `decision` — one of `WOULD_PAUSE`, `WOULD_RESUME`, `PAUSE`, `RESUME`, `MONITORING`, `SKIPPED_COOLDOWN`, `SKIPPED_CAP`, `SKIPPED_LOCK`, `BLOCKED_NOT_ARMED`, `UNKNOWN_DATA`, `ERROR`.
+- `why` — human-readable reasons for the decision.
+- `evidence` — spend, purchase, dry-run, cap, allowlist, exclusion, emergency stop, arming, and reliability snapshot.
+- `blockers` — blocking reasons that prevent trusted or live action.
+- `warnings` — non-fatal data warnings such as missing `omni_purchase`.
+- `insights` — normalized today insight summary, or `null` on per-campaign insight failure.
+
+Missing required `omni_purchase` evidence returns `UNKNOWN_DATA`; it is not treated as zero purchases.
+
+## GET /api/config?accountId=123
+
+Returns normalized config with metadata:
+
+```json
+{
+  "enabled": true,
+  "dryRun": true,
+  "pauseThreshold": 170000,
+  "pauseThreshold2": 200000,
+  "resumeThreshold": 150000,
+  "cooldownHours": 24,
+  "maxActionsPerRun": 0,
+  "maxActionsPerDay": 0,
+  "allowlistCampaignIds": [],
+  "excludeCampaignIds": [],
+  "emergencyStop": false,
+  "arming": {
+    "status": "not_armed",
+    "adAccountConfirmed": false,
+    "recentDryRunRunId": null,
+    "recentDryRunReviewedAt": null,
+    "reviewedBy": null,
+    "reliabilityScore": null,
+    "evidenceWindowDays": 3
+  },
+  "version": null,
+  "updatedAt": null,
+  "updatedBy": null,
+  "liveArmingEligible": false,
+  "armingBlockers": []
+}
+```
+
+## PUT /api/config?accountId=123
+
+The request body must include the full config model and the latest `version` value returned by `GET /api/config`.
+
+Validation rules include:
+
+- `enabled`, `dryRun`, and `emergencyStop` must be booleans.
+- thresholds must be finite numbers greater than or equal to `0`.
+- `pauseThreshold2` may be `null`.
+- `cooldownHours` must be greater than `0`.
+- action caps must be integer values greater than or equal to `0`.
+- allowlist and exclusion fields must be string arrays.
+- `arming` must be an object with valid typed fields.
+
+Version conflicts return `409` with `CONFIG_VERSION_CONFLICT` and the latest config in `data.latestConfig`.
+
+Turning off `dryRun` returns `409` with `LIVE_ARMING_BLOCKED` unless all arming blockers pass.
+
+## GET /api/logs?accountId=123
+
+Returns account-scoped activity timeline entries from KV. The handler also maps legacy action logs into the structured timeline shape.
+
+## GET /api/health
+
+Returns token health:
+
+- success with `status: ok` when Graph API `/me` succeeds.
+- `401 META_TOKEN_INVALID` when Meta returns an auth error.
+- `500 HEALTH_CHECK_FAILED` when the health check itself fails.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,195 @@
+# Operations
+
+This runbook covers local operation, Cloudflare resources, deploy preparation, and incident response for Meta Ads Automation.
+
+## Runtime inventory
+
+- Frontend: Vite static app in `frontend/`.
+- Backend: Cloudflare Worker in `worker/`.
+- KV binding: `CONFIG_KV`.
+- D1 binding: `AUDIT_DB`.
+- Cron: `*/30 * * * *` in `worker/wrangler.jsonc`.
+- Meta API version: Graph API v21.0.
+
+## Required Worker configuration
+
+Secrets:
+
+- `META_ACCESS_TOKEN` — Meta token used for ad account, campaign, insight, pause, and resume calls.
+- `API_AUTH_TOKEN` — optional bearer token for scripted API access.
+
+Vars/bindings:
+
+- `META_ACCOUNT_ID` — default account for scheduled automation, without requiring the `act_` prefix.
+- `FRONTEND_URL` — deployed dashboard origin for CORS and config mutation origin checks.
+- `CONFIG_KV` — KV namespace binding.
+- `AUDIT_DB` — D1 database binding.
+- `ALLOW_LOCAL_DEV` — local-only bypass flag; use `true` only for local development.
+
+Add or update Worker secrets with Wrangler:
+
+```bash
+cd worker
+npx wrangler secret put META_ACCESS_TOKEN
+npx wrangler secret put API_AUTH_TOKEN
+```
+
+Wrangler creates a new Worker version when a secret is updated.
+
+## Local development
+
+`worker/.dev.vars`:
+
+```bash
+META_ACCESS_TOKEN=<meta-token>
+META_ACCOUNT_ID=<default-account-id-without-act-prefix>
+FRONTEND_URL=http://localhost:5173
+ALLOW_LOCAL_DEV=true
+```
+
+Start Worker:
+
+```bash
+cd worker
+npm run dev
+```
+
+Start frontend:
+
+```bash
+cd frontend
+npm run dev
+```
+
+Vite exposes only `VITE_` variables to client code. Use `frontend/.env.local` for `VITE_API_URL` only when needed.
+
+## D1 migrations
+
+Migration files live in `worker/migrations/`. The current schema is `0001_audit_schema.sql`.
+
+Apply local migrations:
+
+```bash
+cd worker
+npx wrangler d1 migrations apply meta-ads-audit --local
+```
+
+Apply remote migrations:
+
+```bash
+cd worker
+npx wrangler d1 migrations apply meta-ads-audit --remote
+```
+
+Wrangler D1 migration apply prompts for confirmation outside CI, captures a backup, and rolls back a failed migration while preserving earlier successful migrations. Wrangler 4 commands default to local mode for resource commands; use `--remote` when intentionally touching remote Cloudflare resources.
+
+## KV usage
+
+The Worker uses KV keys:
+
+- `RULE_CONFIG::<accountId>` for account-scoped config.
+- `RULE_LOGS::<accountId>` for account-scoped timeline logs.
+- `AUTOMATION_RUN_LOCK` for scheduled-run overlap protection.
+
+Use remote KV commands only when intentionally inspecting or changing deployed state.
+
+## Deploy checklist
+
+Before deploying:
+
+1. Run Worker tests: `cd worker && npm test`.
+2. Run frontend checks: `cd frontend && npm run lint && npm run build`.
+3. Apply D1 migrations to the target database.
+4. Confirm `FRONTEND_URL` matches the deployed dashboard origin.
+5. Confirm `META_ACCOUNT_ID` is the account intended for scheduled automation.
+6. Confirm `META_ACCESS_TOKEN` permissions and expiry.
+7. Confirm deployed `/api/*` auth path: Cloudflare Access or bearer token.
+8. Keep `dryRun: true` until a human has reviewed recent dry-run evidence.
+9. Confirm allowlist, action caps, ad account confirmation, and emergency stop state before live mode.
+
+Deploy Worker:
+
+```bash
+cd worker
+npx wrangler deploy
+```
+
+Build frontend:
+
+```bash
+cd frontend
+npm run build
+```
+
+Deploy the built frontend through the selected host, such as Vercel.
+
+## Scheduled automation runbook
+
+Healthy run behavior:
+
+- A run gets a unique `runId`.
+- A KV lock is acquired for up to 25 minutes.
+- Campaign and insight data are fetched from Meta.
+- Decisions are logged as dry-run, live, skipped, or failed entries.
+- D1 records the run lifecycle and campaign state updates.
+- KV keeps the recent timeline for dashboard reads.
+
+If a run overlaps:
+
+- The second run records `SKIPPED_LOCK`.
+- D1 status becomes `skipped_overlap` when `AUDIT_DB` is available.
+
+If Meta insights fail globally:
+
+- The run records `AUTOMATION_RUN_FAILED`.
+- D1 status becomes `failed`.
+- Treat this as fail-closed. Do not infer purchases from missing evidence.
+
+## Emergency stop
+
+Use config to enable `emergencyStop: true`. Live mode is blocked when emergency stop is on.
+
+If the dashboard is unavailable, update the account-scoped config through a trusted authenticated API client and preserve the latest config `version` to avoid conflicts.
+
+## Live-mode checklist
+
+Do not disable dry-run until all are true:
+
+- Ad account has been confirmed by a human.
+- Recent dry-run output has been reviewed.
+- `allowlistCampaignIds` contains only intended campaign IDs.
+- `excludeCampaignIds` contains campaigns that must never be touched.
+- `maxActionsPerRun` and `maxActionsPerDay` are positive and conservative.
+- `emergencyStop` is false.
+- D1 audit writes are succeeding.
+- Resume provenance is populated for campaigns paused by this tool.
+
+## Troubleshooting
+
+### API returns `ACCESS_UNAUTHORIZED`
+
+Check one of the auth paths:
+
+- local request plus `ALLOW_LOCAL_DEV=true`
+- `Authorization: Bearer <API_AUTH_TOKEN>`
+- Cloudflare Access identity header
+
+### Config write returns `ORIGIN_FORBIDDEN`
+
+Confirm the request origin or referer matches `FRONTEND_URL`, or use the local dev bypass from localhost.
+
+### Config write returns `CONFIG_VERSION_CONFLICT`
+
+Reload config, merge the intended changes onto the latest version, and retry with the latest `version`.
+
+### Config write returns `LIVE_ARMING_BLOCKED`
+
+Review `armingBlockers`. The backend blocks live mode until all required safety evidence exists.
+
+### Campaign decisions show `UNKNOWN_DATA`
+
+The backend did not receive complete `omni_purchase` evidence. Check Meta insight payloads and avoid treating the missing metric as zero purchases.
+
+### Resume is skipped for provenance
+
+The campaign was not recorded as paused by this tool in `campaign_states`. Manual pauses should not be auto-resumed by this automation.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,100 @@
+# Security
+
+Meta Ads Automation can mutate paid advertising campaigns. Treat auth, origin checks, audit logs, and live-mode controls as product safety features, not just technical controls.
+
+## Current protection layers
+
+### API authentication
+
+Every `/api/*` request except `OPTIONS` must satisfy one of:
+
+- localhost request with `ALLOW_LOCAL_DEV=true`
+- `Authorization: Bearer <API_AUTH_TOKEN>`
+- `CF-Access-Jwt-Assertion` from Cloudflare Access
+
+Local bypass is intended for development only.
+
+### Mutation origin guard
+
+`PUT /api/config` requires an allowed origin or referer:
+
+- localhost when local bypass is enabled
+- the origin from `FRONTEND_URL` in deployed environments
+
+This reduces accidental cross-site config writes. It does not replace authentication.
+
+### Secrets
+
+Worker secrets belong in Cloudflare secrets or local `worker/.dev.vars`.
+
+Do not expose secrets through Vite. Only `VITE_` variables are available to client code, so never put Meta tokens or API bearer tokens behind a `VITE_` prefix.
+
+### Fail-closed insight handling
+
+Automation decisions require `omni_purchase` evidence. Missing purchase evidence produces `UNKNOWN_DATA` and blockers instead of assuming zero purchases.
+
+### Dry-run default
+
+Default config uses `dryRun: true`. In dry-run, the system logs `WOULD_PAUSE` and `WOULD_RESUME` decisions without calling Meta mutation endpoints.
+
+### Live-mode arming
+
+Live mode is blocked unless arming requirements pass:
+
+- ad account confirmed
+- allowlist present
+- action caps present
+- recent dry-run review present
+- emergency stop off
+
+Live resume also requires D1 provenance that the campaign was paused by this tool.
+
+### Audit persistence
+
+D1 stores:
+
+- config versions
+- automation runs
+- campaign state/provenance
+- action logs
+
+KV also stores recent account-scoped timeline entries for dashboard reads.
+
+## Deployment expectations
+
+For deployed browser use, prefer a same-origin or Cloudflare Access-protected deployment path so the Worker receives an identity assertion without placing tokens in client code.
+
+If using `API_AUTH_TOKEN` from browser code, update and verify CORS first. The current CORS preflight allows `Content-Type`, while browser bearer auth requires `Authorization` to be allowed.
+
+## Known security gaps to verify before production
+
+- Frontend auth plumbing is not complete for bearer-token deployments.
+- Cloudflare Access policy and same-origin deployment contract need live validation.
+- Full cooldown and action-cap enforcement should be verified before live mode.
+- Dashboard browser QA should cover blocked-live, unknown-data, version-conflict, and auth-failure states.
+- External notifications are not implemented, so operators must monitor dashboard/logs until alerting exists.
+
+## Handling incidents
+
+### Suspected bad automation decision
+
+1. Enable `emergencyStop` in account config.
+2. Confirm the latest config version was saved.
+3. Review `action_logs` and `automation_runs` in D1.
+4. Check `RULE_LOGS::<accountId>` for recent timeline entries.
+5. Manually verify campaign status in Meta Ads Manager.
+6. Do not re-enable live mode until the decision evidence and blockers are understood.
+
+### Token exposure
+
+1. Revoke or rotate the Meta token.
+2. Update `META_ACCESS_TOKEN` with `npx wrangler secret put META_ACCESS_TOKEN`.
+3. Review recent Meta and Worker activity.
+4. Check git history and local files for accidental secret commits.
+
+### Unauthorized API access attempt
+
+1. Review Cloudflare Access logs or Worker logs.
+2. Rotate `API_AUTH_TOKEN` if bearer auth is enabled.
+3. Confirm `FRONTEND_URL` and origin guard behavior.
+4. Keep `dryRun` enabled until the access path is understood.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,47 @@
+# Architecture Decision Records
+
+Store durable design decisions in this directory.
+
+Use an ADR when a decision changes how future contributors should reason about the system, such as:
+
+- auth model
+- persistence model
+- live automation safety gates
+- deployment topology
+- API contract shape
+- data semantics for Meta metrics
+
+## File naming
+
+```text
+0001-short-decision-title.md
+0002-another-decision.md
+```
+
+## Template
+
+```markdown
+# ADR-0001: Decision title
+
+## Status
+
+Accepted | Superseded | Proposed
+
+## Context
+
+What problem or constraint forced this decision?
+
+## Decision
+
+What did we choose?
+
+## Consequences
+
+What becomes easier, harder, or riskier because of this?
+
+## Related
+
+- Links to issues, PRs, docs, or plans.
+```
+
+Keep ADRs short and factual. Do not use ADRs as implementation plans.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,73 +1,67 @@
-# React + TypeScript + Vite
+# Frontend Dashboard
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Vite + React + TypeScript dashboard for Meta Ads Automation.
 
-Currently, two official plugins are available:
+## What it does
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+- Checks Worker health.
+- Lists Meta ad accounts available to the configured backend token.
+- Requires an operator to choose an ad account before loading campaigns and rules.
+- Loads account-scoped campaigns, config, and logs from the Worker API.
+- Displays campaign spend, purchases, status, and a local action hint.
+- Saves threshold config through `PUT /api/config?accountId=...`.
+- Polls selected-account data every 60 seconds.
 
-## React Compiler
+## Scripts
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm run dev      # Start Vite dev server
+npm run build    # Type-check and build production assets
+npm run lint     # Run ESLint
+npm run preview  # Preview the built app locally
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+## Environment
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+The API base URL comes from `VITE_API_URL` and falls back to `http://localhost:8787`.
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+Use `frontend/.env.local` when needed:
+
+```bash
+VITE_API_URL=http://localhost:8787
 ```
+
+Only `VITE_` variables are exposed to browser code. Do not place Meta tokens or API bearer tokens in frontend env files.
+
+## Local development
+
+Start the Worker first:
+
+```bash
+cd ../worker
+npm run dev
+```
+
+Then start Vite:
+
+```bash
+cd ../frontend
+npm run dev
+```
+
+Open the Vite URL, confirm the API health badge, choose an ad account, and verify campaigns/config load.
+
+## Important files
+
+- `src/main.tsx` — React mount.
+- `src/App.tsx` — renders `Dashboard`.
+- `src/components/Dashboard.tsx` — dashboard state, polling, account selection, config editing, sorting, and table rendering.
+- `src/lib/api.ts` — `apiFetch()` and API base URL resolution.
+- `src/types.ts` — frontend API types.
+- `tailwind.config.js` — Tailwind/shadcn content and theme configuration.
+
+## Current frontend gaps
+
+The dashboard still computes some action hints locally for display. The backend already returns richer decision, evidence, blocker, warning, and error fields; future frontend work should render those backend truth fields directly.
+
+Browser QA is still required for account selection, auth failure, config save, version conflict, blocked live mode, unknown data, and responsive states.

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
-import { Activity, Settings, RefreshCw, AlertCircle, PlayCircle, PauseCircle, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
+import { Activity, Settings, RefreshCw, AlertCircle, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
 
 export default function Dashboard() {
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { apiFetch } from "@/lib/api";
-import type { Campaign, RuleConfig } from "@/types";
+import type { AdAccount, ApiSuccessResponse, Campaign, RuleConfig } from "@/types";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
@@ -12,23 +12,49 @@ import { Activity, Settings, RefreshCw, AlertCircle, ArrowUpDown, ArrowUp, Arrow
 
 export default function Dashboard() {
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
+  const [adAccounts, setAdAccounts] = useState<AdAccount[]>([]);
+  const [selectedAccountId, setSelectedAccountId] = useState("");
   const [config, setConfig] = useState<RuleConfig | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [health, setHealth] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [accountsLoading, setAccountsLoading] = useState(true);
+  const [health, setHealth] = useState<{ status?: string } | null>(null);
   const [sortKey, setSortKey] = useState<string>("name");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
 
+  const fetchAccounts = async () => {
+    setAccountsLoading(true);
+    try {
+      const [accountsRes, healthRes] = await Promise.all([
+        apiFetch<ApiSuccessResponse<AdAccount[]>>("/api/ad-accounts"),
+        apiFetch<ApiSuccessResponse<{ status?: string }>>("/api/health")
+      ]);
+      setAdAccounts(accountsRes.data || []);
+      setHealth(healthRes.data);
+    } catch (e) {
+      console.error("Error fetching accounts:", e);
+    } finally {
+      setAccountsLoading(false);
+    }
+  };
+
   const fetchData = async () => {
+    if (!selectedAccountId) {
+      setCampaigns([]);
+      setConfig(null);
+      return;
+    }
+
     setLoading(true);
     try {
-      const [campsRes, configRes, healthRes] = await Promise.all([
-        apiFetch("/api/campaigns"),
-        apiFetch("/api/config"),
-        apiFetch("/api/health")
+      const accountQuery = `accountId=${encodeURIComponent(selectedAccountId)}`;
+      const [campsRes, configRes, logsRes] = await Promise.all([
+        apiFetch<ApiSuccessResponse<Campaign[]>>(`/api/campaigns?${accountQuery}`),
+        apiFetch<ApiSuccessResponse<RuleConfig>>(`/api/config?${accountQuery}`),
+        apiFetch(`/api/logs?${accountQuery}`)
       ]);
+      void logsRes;
       setCampaigns(campsRes.data || []);
       setConfig(configRes.data);
-      setHealth(healthRes);
     } catch (e) {
       console.error("Error fetching data:", e);
     } finally {
@@ -37,15 +63,20 @@ export default function Dashboard() {
   };
 
   useEffect(() => {
-    fetchData();
-    const interval = setInterval(fetchData, 60000); // refresh every minute
-    return () => clearInterval(interval);
+    fetchAccounts();
   }, []);
 
+  useEffect(() => {
+    fetchData();
+    const interval = setInterval(fetchData, 60000);
+    return () => clearInterval(interval);
+  }, [selectedAccountId]);
+
   const handleConfigSave = async () => {
-    if (!config) return;
+    if (!config || !selectedAccountId) return;
     try {
-      await apiFetch("/api/config", {
+      const accountQuery = `accountId=${encodeURIComponent(selectedAccountId)}`;
+      await apiFetch(`/api/config?${accountQuery}`, {
         method: "PUT",
         body: JSON.stringify(config)
       });
@@ -69,30 +100,37 @@ export default function Dashboard() {
     return sortOrder === "asc" ? <ArrowUp className="ml-2 h-4 w-4 inline-block" /> : <ArrowDown className="ml-2 h-4 w-4 inline-block" />;
   };
 
+  const getSpend = (campaign: Campaign) => campaign.insights?.spend ?? 0;
+  const getPurchases = (campaign: Campaign) => campaign.insights?.purchases ?? 0;
+
+  const getActionWeight = (campaign: Campaign) => {
+    const spend = getSpend(campaign);
+    const purchases = getPurchases(campaign);
+
+    if (campaign.status === 'ACTIVE' && (
+      (spend > (config?.pauseThreshold ?? 9999) && purchases === 0) ||
+      (spend > (config?.pauseThreshold2 ?? 9999) && purchases < 2)
+    )) return 2;
+    if (campaign.status === 'PAUSED' && spend < (config?.resumeThreshold ?? 0) && purchases > 0) return 1;
+    return 0;
+  };
+
+  const shouldPause = (campaign: Campaign) => getActionWeight(campaign) === 2;
+  const shouldResume = (campaign: Campaign) => getActionWeight(campaign) === 1;
+
   const sortedCampaigns = [...campaigns].sort((a, b) => {
-    let aVal: any = a[sortKey as keyof Campaign];
-    let bVal: any = b[sortKey as keyof Campaign];
+    let aVal: string | number = a[sortKey as keyof Campaign]?.toString().toLowerCase() || '';
+    let bVal: string | number = b[sortKey as keyof Campaign]?.toString().toLowerCase() || '';
 
     if (sortKey === 'spend') {
-      aVal = parseFloat(a.insights?.spend || '0');
-      bVal = parseFloat(b.insights?.spend || '0');
+      aVal = getSpend(a);
+      bVal = getSpend(b);
     } else if (sortKey === 'purchases') {
-      aVal = a.insights?.purchases || 0;
-      bVal = b.insights?.purchases || 0;
+      aVal = getPurchases(a);
+      bVal = getPurchases(b);
     } else if (sortKey === 'action') {
-      const getActionWeight = (camp: Campaign) => {
-        if (camp.status === 'ACTIVE' && (
-          (parseFloat(camp.insights?.spend || '0') > (config?.pauseThreshold || 9999) && (camp.insights?.purchases || 0) === 0) ||
-          (parseFloat(camp.insights?.spend || '0') > (config?.pauseThreshold2 || 9999) && (camp.insights?.purchases || 0) < 2)
-        )) return 2;
-        if (camp.status === 'PAUSED' && parseFloat(camp.insights?.spend || '0') < (config?.resumeThreshold || 0) && (camp.insights?.purchases || 0) > 0) return 1;
-        return 0;
-      };
       aVal = getActionWeight(a);
       bVal = getActionWeight(b);
-    } else if (sortKey === 'name' || sortKey === 'status') {
-      aVal = aVal?.toString().toLowerCase() || '';
-      bVal = bVal?.toString().toLowerCase() || '';
     }
 
     if (aVal < bVal) return sortOrder === "asc" ? -1 : 1;
@@ -120,11 +158,36 @@ export default function Dashboard() {
                 <AlertCircle className="w-4 h-4 mr-1" /> API Disconnected
               </Badge>
             )}
-            <Button onClick={fetchData} variant="outline" size="icon" disabled={loading}>
+            <Button onClick={fetchData} variant="outline" size="icon" disabled={loading || !selectedAccountId}>
               <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
             </Button>
           </div>
         </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Ad Account</CardTitle>
+            <CardDescription>Select an account before loading campaigns and rules.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Label htmlFor="ad-account">Account</Label>
+            <select
+              id="ad-account"
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              value={selectedAccountId}
+              onChange={(event) => setSelectedAccountId(event.target.value)}
+              disabled={accountsLoading}
+            >
+              <option value="">{accountsLoading ? "Loading accounts..." : "Chọn account trước"}</option>
+              {adAccounts.map((account) => (
+                <option key={account.id} value={account.account_id}>
+                  {account.name} ({account.account_id})
+                </option>
+              ))}
+            </select>
+            {!selectedAccountId && <p className="text-sm text-slate-500">Chọn account trước.</p>}
+          </CardContent>
+        </Card>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           {/* Main Content: Campaigns */}
@@ -156,7 +219,13 @@ export default function Dashboard() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {campaigns.length === 0 ? (
+                    {!selectedAccountId ? (
+                      <TableRow>
+                        <TableCell colSpan={5} className="text-center text-slate-500 py-8">
+                          Chọn account trước.
+                        </TableCell>
+                      </TableRow>
+                    ) : campaigns.length === 0 ? (
                       <TableRow>
                         <TableCell colSpan={5} className="text-center text-slate-500 py-8">
                           No campaigns found.
@@ -173,15 +242,12 @@ export default function Dashboard() {
                               {camp.status}
                             </Badge>
                           </TableCell>
-                          <TableCell className="text-right">{parseFloat(camp.insights?.spend?.toString() || '0').toLocaleString('vi-VN')} ₫</TableCell>
-                          <TableCell className="text-right">{camp.insights?.purchases || 0}</TableCell>
+                          <TableCell className="text-right">{getSpend(camp).toLocaleString('vi-VN')} ₫</TableCell>
+                          <TableCell className="text-right">{getPurchases(camp)}</TableCell>
                           <TableCell className="text-right">
-                            {camp.status === 'ACTIVE' && (
-                              (parseFloat(camp.insights?.spend || '0') > (config?.pauseThreshold || 9999) && (camp.insights?.purchases || 0) === 0) ||
-                              (parseFloat(camp.insights?.spend || '0') > (config?.pauseThreshold2 || 9999) && (camp.insights?.purchases || 0) < 2)
-                            ) ? (
+                            {shouldPause(camp) ? (
                               <Badge variant="destructive" className="ml-auto">Will Pause</Badge>
-                            ) : camp.status === 'PAUSED' && parseFloat(camp.insights?.spend || '0') < (config?.resumeThreshold || 0) && (camp.insights?.purchases || 0) > 0 ? (
+                            ) : shouldResume(camp) ? (
                               <Badge className="bg-green-500 ml-auto">Will Resume</Badge>
                             ) : (
                               <span className="text-slate-400 text-sm">Monitoring</span>
@@ -207,7 +273,9 @@ export default function Dashboard() {
                 <CardDescription>Configure thresholds for pausing and resuming.</CardDescription>
               </CardHeader>
               <CardContent className="space-y-6">
-                {config ? (
+                {!selectedAccountId ? (
+                  <p className="text-sm text-slate-500">Chọn account trước.</p>
+                ) : config ? (
                   <>
                     <div className="flex items-center justify-between">
                       <Label htmlFor="enabled" className="text-base font-medium">Enable Automation</Label>
@@ -247,7 +315,7 @@ export default function Dashboard() {
                         onChange={(e) => setConfig({ ...config, resumeThreshold: Number(e.target.value) })}
                       />
                     </div>
-                    <Button className="w-full" onClick={handleConfigSave}>
+                    <Button className="w-full" onClick={handleConfigSave} disabled={!selectedAccountId}>
                       Save Configuration
                     </Button>
                   </>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,8 @@
+import type { ApiSuccessResponse } from "@/types";
+
 const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8787";
 
-export async function apiFetch(endpoint: string, options: RequestInit = {}) {
+export async function apiFetch<T = ApiSuccessResponse<unknown>>(endpoint: string, options: RequestInit = {}): Promise<T> {
   const url = `${API_BASE_URL}${endpoint}`;
   const response = await fetch(url, {
     ...options,
@@ -15,5 +17,5 @@ export async function apiFetch(endpoint: string, options: RequestInit = {}) {
     throw new Error(errorData.message || `API Error: ${response.status} ${response.statusText}`);
   }
 
-  return response.json();
+  return response.json() as Promise<T>;
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -262,4 +262,3 @@ export interface LegacyCampaign {
 
 export type Campaign = LegacyCampaign;
 export type CampaignEnriched = CampaignDecisionRow;
-

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,16 +1,243 @@
+export type CampaignStatus = 'ACTIVE' | 'PAUSED';
+export type PurchaseMetric = 'omni_purchase';
+export type DecisionType =
+  | 'WOULD_PAUSE'
+  | 'WOULD_RESUME'
+  | 'PAUSE'
+  | 'RESUME'
+  | 'MONITORING'
+  | 'SKIPPED_COOLDOWN'
+  | 'SKIPPED_CAP'
+  | 'SKIPPED_LOCK'
+  | 'BLOCKED_NOT_ARMED'
+  | 'UNKNOWN_DATA'
+  | 'ERROR';
+export type RunStatus = 'started' | 'completed' | 'failed' | 'skipped_overlap' | 'blocked_live_gate';
+export type HealthStatus = 'ok' | 'degraded' | 'error';
+export type ConfigWriteStatus = 'saved' | 'validation_error' | 'version_conflict' | 'blocked_live_gate';
+export type ActivitySource = 'dry_run' | 'live' | 'system';
+export type DataState = 'complete' | 'partial' | 'missing' | 'error';
+export type WarningSeverity = 'info' | 'warning' | 'error';
+export type ArmingStatus = 'not_armed' | 'eligible' | 'armed' | 'blocked';
+export type BlockerCode =
+  | 'AD_ACCOUNT_CONFIRMATION_REQUIRED'
+  | 'ALLOWLIST_REQUIRED'
+  | 'ACTION_CAPS_REQUIRED'
+  | 'RECENT_DRY_RUN_REVIEW_REQUIRED'
+  | 'EMERGENCY_STOP'
+  | 'COOLDOWN_ACTIVE'
+  | 'RUN_CAP_REACHED'
+  | 'DAY_CAP_REACHED'
+  | 'CAMPAIGN_NOT_ALLOWED'
+  | 'CAMPAIGN_EXCLUDED'
+  | 'LOCK_ACTIVE'
+  | 'PROVENANCE_REQUIRED'
+  | 'GLOBAL_INSIGHTS_UNAVAILABLE'
+  | 'MISSING_OMNI_PURCHASE';
+export type WarningCode = 'MISSING_OMNI_PURCHASE' | 'PARTIAL_INSIGHTS' | 'INSIGHTS_UNAVAILABLE';
+
+export interface ApiValidationErrorDetail {
+  field: string;
+  code: string;
+  message: string;
+}
+
+export interface ClassifiedError {
+  category: 'auth' | 'config' | 'global_insights' | 'campaign_mutation' | 'validation';
+  code: string;
+  message: string;
+  retryable: boolean;
+  details?: ApiValidationErrorDetail[];
+}
+
+export interface BlockerReason {
+  code: BlockerCode;
+  message: string;
+  blocking: boolean;
+}
+
+export interface DataWarning {
+  code: WarningCode;
+  message: string;
+  severity: WarningSeverity;
+}
+
+export interface ArmingState {
+  status: ArmingStatus;
+  adAccountConfirmed: boolean;
+  recentDryRunRunId: string | null;
+  recentDryRunReviewedAt: string | null;
+  reviewedBy: string | null;
+  reliabilityScore: number | null;
+  evidenceWindowDays: number;
+}
+
 export interface RuleConfig {
-  pauseThreshold: number;
-  pauseThreshold2?: number;
-  resumeThreshold: number;
   enabled: boolean;
+  dryRun?: boolean;
+  pauseThreshold: number;
+  pauseThreshold2?: number | null;
+  resumeThreshold: number;
+  cooldownHours?: number;
+  maxActionsPerRun?: number;
+  maxActionsPerDay?: number;
+  allowlistCampaignIds?: string[];
+  excludeCampaignIds?: string[];
+  emergencyStop?: boolean;
+  arming?: Partial<ArmingState>;
+}
+
+export interface NormalizedRuleConfig extends RuleConfig {
+  dryRun: boolean;
+  pauseThreshold2: number | null;
+  cooldownHours: number;
+  maxActionsPerRun: number;
+  maxActionsPerDay: number;
+  allowlistCampaignIds: string[];
+  excludeCampaignIds: string[];
+  emergencyStop: boolean;
+  arming: ArmingState;
 }
 
 export interface CampaignInsight {
   campaignId: string;
   campaignName: string;
-  status: 'ACTIVE' | 'PAUSED';
+  status: CampaignStatus;
   spend: number;
   purchaseCount: number;
+  purchaseMetric: PurchaseMetric;
+  hasPurchaseMetric: boolean;
+  dataState: DataState;
+}
+
+export interface CampaignInsightsSummary {
+  spend: number;
+  purchases: number;
+  purchaseMetric: PurchaseMetric;
+  hasPurchaseMetric: boolean;
+  dataState: DataState;
+}
+
+export interface CampaignSnapshot {
+  id: string;
+  name: string;
+  status: CampaignStatus;
+  spendToday: number | null;
+  purchasesToday: number | null;
+  purchases3d: number | null;
+  purchaseMetric: PurchaseMetric;
+  hasPurchaseMetric: boolean;
+  dataState: DataState;
+}
+
+export interface DecisionEvidence {
+  spendToday: number | null;
+  purchasesToday: number | null;
+  purchases3d: number | null;
+  purchaseMetric: PurchaseMetric;
+  dataState: DataState;
+  dryRun: boolean;
+  cooldownHours: number;
+  maxActionsPerRun: number;
+  maxActionsPerDay: number;
+  allowlisted: boolean;
+  excluded: boolean;
+  emergencyStop: boolean;
+  armingStatus: ArmingStatus;
+  reliabilityScore: number | null;
+}
+
+export interface CampaignDecisionRow {
+  id: string;
+  name: string;
+  status: CampaignStatus;
+  decision: DecisionType;
+  why: string[];
+  evidence: DecisionEvidence;
+  blockers: BlockerReason[];
+  campaignSnapshot: CampaignSnapshot;
+  warnings: DataWarning[];
+  error: ClassifiedError | null;
+  insights: CampaignInsightsSummary | null;
+}
+
+export interface ActivityTimelineItem {
+  id: string;
+  runId: string | null;
+  campaignId: string | null;
+  campaignName: string | null;
+  decision: DecisionType;
+  source: ActivitySource;
+  status: 'applied' | 'skipped' | 'failed';
+  occurredAt: string;
+  why: string[];
+  blockers: BlockerReason[];
+  warnings: DataWarning[];
+  error: ClassifiedError | null;
+  evidence: DecisionEvidence | null;
+}
+
+export interface RunHealthSummary {
+  currentStatus: RunStatus | null;
+  lastStartedAt: string | null;
+  lastCompletedAt: string | null;
+  lastFailedAt: string | null;
+  nextScheduledAt: string | null;
+  activeLock: boolean;
+  activeRunId: string | null;
+}
+
+export interface ConfigReadModel extends NormalizedRuleConfig {
+  dryRun: boolean;
+  pauseThreshold2: number | null;
+  cooldownHours: number;
+  maxActionsPerRun: number;
+  maxActionsPerDay: number;
+  allowlistCampaignIds: string[];
+  excludeCampaignIds: string[];
+  emergencyStop: boolean;
+  arming: ArmingState;
+  version: number | null;
+  updatedAt: string | null;
+  updatedBy: string | null;
+  liveArmingEligible: boolean;
+  armingBlockers: BlockerReason[];
+}
+
+export interface ConfigVersionConflictMetadata {
+  currentVersion: number | null;
+  submittedVersion: number | null;
+  latestConfig: ConfigReadModel;
+}
+
+export interface HealthPayload {
+  status: HealthStatus;
+  message: string;
+  checkedAt: string;
+  metaAccountId: string;
+}
+
+export interface ApiResponseMeta {
+  generatedAt: string;
+  total?: number;
+  version?: number | null;
+  run?: RunHealthSummary | null;
+}
+
+export interface ApiSuccessResponse<T, M = ApiResponseMeta> {
+  success: true;
+  data: T;
+  error: null;
+  message?: string;
+  meta?: M;
+}
+
+export interface ApiErrorResponse<T = null, M = ApiResponseMeta> {
+  success: false;
+  data: T;
+  error: ClassifiedError;
+  message: string;
+  meta?: M;
 }
 
 export interface RuleAction {
@@ -23,11 +250,16 @@ export interface RuleAction {
   purchaseCount: number;
 }
 
-export interface Campaign extends CampaignInsight {
+export interface LegacyCampaign {
   id: string;
   name: string;
+  status: CampaignStatus;
   insights?: {
-    spend: number;
+    spend: string;
     purchases: number;
-  };
+  } | null;
 }
+
+export type Campaign = LegacyCampaign;
+export type CampaignEnriched = CampaignDecisionRow;
+

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,3 +1,10 @@
+export interface AdAccount {
+  id: string;
+  account_id: string;
+  name: string;
+  account_status: number;
+}
+
 export type CampaignStatus = 'ACTIVE' | 'PAUSED';
 export type PurchaseMetric = 'omni_purchase';
 export type DecisionType =
@@ -260,5 +267,5 @@ export interface LegacyCampaign {
   } | null;
 }
 
-export type Campaign = LegacyCampaign;
+export type Campaign = CampaignDecisionRow;
 export type CampaignEnriched = CampaignDecisionRow;

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -21,6 +21,7 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": [
         "./src/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1501 @@
+{
+  "name": "meta-ads",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "wrangler": "^4.87.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260430.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260430.1.tgz",
+      "integrity": "sha512-ADohZUHf7NBvPp2PdZig2Opxx+hDkk3ve7jrTne3JRx9kDSB73zc4LzcEeEN8LKkbAcqZmvfRJfpChSlusu0lA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260430.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260430.1.tgz",
+      "integrity": "sha512-/DoYC/1wHs+YRZzzqSQg1/EHB4hiv1yV5U8FnmapRRIzVaPtnt+ApeOXeMrIdKidgKOI8TqQzgBU8xbIM7Cl4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260430.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260430.1.tgz",
+      "integrity": "sha512-koJhBWvEVZPKCVFtMLp2iMHlYr+lFCF47wGbnlKdHVlemV0zTxJEyHI8aLlrhPLhBmOmYLp46rXw09/qJkRIhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260430.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260430.1.tgz",
+      "integrity": "sha512-hMdapNAzNQZDXGGkg4Slydc3fRJP5FUZLJVVcZCW/+imhhJro9Z1rv5n/wfR+txKoSWhTYR8eOp8Pyi2bzLzlw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260430.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260430.1.tgz",
+      "integrity": "sha512-jS3ffixjb5USOwz4frw4WzCz0HrjVxkgyU3WiYb06N7hBAfN6eOrveAJ4QRef0+suK4V1vQFoB1oKdRBsXe9Dw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260430.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260430.0.tgz",
+      "integrity": "sha512-MWvMm3Siho9Yj7lbJZidLs8hbrRvIcOrif2mnsHQZdvoKfedpea+GaN8XJxbpRcq0B2WzNI1BB1ihdnqes3/ZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260430.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260430.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260430.1.tgz",
+      "integrity": "sha512-KEgIWyiw3Jmn+DCd/L3ePo5fmiiYb/UcwKvDWPf/nLLOiwShDFzDSsegU5NY/JcwgvO/QsLHVi2FYrbkcXNY5Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260430.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260430.1",
+        "@cloudflare/workerd-linux-64": "1.20260430.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260430.1",
+        "@cloudflare/workerd-windows-64": "1.20260430.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.87.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.87.0.tgz",
+      "integrity": "sha512-lfhfKwLfQlowwgV0xhlYgE9fU3n0I30d4ccGY/rTCEm/n42Mjvlr0Ng3ZPNqlsrsKBcDR531V7dsPkgELvrk/Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260430.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260430.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260430.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "wrangler": "^4.87.0"
+  }
+}

--- a/worker/migrations/0001_audit_schema.sql
+++ b/worker/migrations/0001_audit_schema.sql
@@ -1,0 +1,53 @@
+CREATE TABLE IF NOT EXISTS config_versions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  version INTEGER NOT NULL,
+  configJson TEXT NOT NULL,
+  createdAt TEXT NOT NULL,
+  createdBy TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_config_versions_version
+  ON config_versions(version);
+
+CREATE TABLE IF NOT EXISTS automation_runs (
+  id TEXT PRIMARY KEY,
+  status TEXT NOT NULL,
+  startedAt TEXT NOT NULL,
+  completedAt TEXT,
+  failedAt TEXT,
+  summaryJson TEXT,
+  errorJson TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_automation_runs_status_started_at
+  ON automation_runs(status, startedAt DESC);
+
+CREATE TABLE IF NOT EXISTS campaign_states (
+  campaignId TEXT PRIMARY KEY,
+  lastDecision TEXT,
+  lastAction TEXT,
+  lastActionAt TEXT,
+  lastRunId TEXT,
+  pausedByTool INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_campaign_states_last_run_id
+  ON campaign_states(lastRunId);
+
+CREATE TABLE IF NOT EXISTS action_logs (
+  id TEXT PRIMARY KEY,
+  runId TEXT NOT NULL,
+  campaignId TEXT,
+  decision TEXT NOT NULL,
+  source TEXT NOT NULL,
+  status TEXT NOT NULL,
+  occurredAt TEXT NOT NULL,
+  payloadJson TEXT NOT NULL,
+  FOREIGN KEY (runId) REFERENCES automation_runs(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_action_logs_run_id_occurred_at
+  ON action_logs(runId, occurredAt DESC);
+
+CREATE INDEX IF NOT EXISTS idx_action_logs_campaign_id_occurred_at
+  ON action_logs(campaignId, occurredAt DESC);

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.12.3",
         "@cloudflare/workers-types": "^4.20260501.1",
         "typescript": "^6.0.3",
+        "vitest": "^3.2.4",
         "wrangler": "^4.87.0"
       }
     },
@@ -36,6 +38,222 @@
       },
       "peerDependenciesMeta": {
         "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.12.21",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.12.21.tgz",
+      "integrity": "sha512-xqvqVR+qAhekXWaTNY36UtFFmHrz13yGUoWVGOu6LDC2ABiQqI1E1lQ3eUZY8KVB+1FXY/mP5dB6oD07XUGnPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cjs-module-lexer": "^1.2.3",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260310.0",
+        "wrangler": "4.72.0"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "2.0.x - 3.2.x",
+        "@vitest/snapshot": "2.0.x - 3.2.x",
+        "vitest": "2.0.x - 3.2.x"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/unenv-preset": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.15.0.tgz",
+      "integrity": "sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260310.1.tgz",
+      "integrity": "sha512-hF2VpoWaMb1fiGCQJqCY6M8I+2QQqjkyY4LiDYdTL5D/w6C1l5v1zhc0/jrjdD1DXfpJtpcSMSmEPjHse4p9Ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260310.1.tgz",
+      "integrity": "sha512-h/Vl3XrYYPI6yFDE27XO1QPq/1G1lKIM8tzZGIWYpntK3IN5XtH3Ee/sLaegpJ49aIJoqhF2mVAZ6Yw+Vk2gJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260310.1.tgz",
+      "integrity": "sha512-XzQ0GZ8G5P4d74bQYOIP2Su4CLdNPpYidrInaSOuSxMw+HamsHaFrjVsrV2mPy/yk2hi6SY2yMbgKFK9YjA7vw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260310.1.tgz",
+      "integrity": "sha512-sxv4CxnN4ZR0uQGTFVGa0V4KTqwdej/czpIc5tYS86G8FQQoGIBiAIs2VvU7b8EROPcandxYHDBPTb+D9HIMPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260310.1.tgz",
+      "integrity": "sha512-+1ZTViWKJypLfgH/luAHCqkent0DEBjAjvO40iAhOMHRLYP/SPphLvr4Jpi6lb+sIocS8Q1QZL4uM5Etg1Wskg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/miniflare": {
+      "version": "4.20260310.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260310.0.tgz",
+      "integrity": "sha512-uC5vNPenFpDSj5aUU3wGSABG6UUqMr+Xs1m4AkCrTHo37F4Z6xcQw5BXqViTfPDVT/zcYH1UgTVoXhr1l6ZMXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.18.2",
+        "workerd": "1.20260310.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/undici": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
+      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/workerd": {
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260310.1.tgz",
+      "integrity": "sha512-yawXhypXXHtArikJj15HOMknNGikpBbSg2ZDe6lddUbqZnJXuCVSkgc/0ArUeVMG1jbbGvpst+REFtKwILvRTQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260310.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260310.1",
+        "@cloudflare/workerd-linux-64": "1.20260310.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260310.1",
+        "@cloudflare/workerd-windows-64": "1.20260310.1"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
+      "version": "4.72.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.72.0.tgz",
+      "integrity": "sha512-bKkb8150JGzJZJWiNB2nu/33smVfawmfYiecA6rW4XH7xS23/jqMbgpdelM34W/7a1IhR66qeQGVqTRXROtAZg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.15.0",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260310.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260310.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260310.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
           "optional": true
         }
       }
@@ -1145,6 +1363,356 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
@@ -1165,10 +1733,204 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -1184,6 +1946,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -1205,6 +1995,13 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1248,6 +2045,44 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1263,6 +2098,13 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -1271,6 +2113,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/miniflare": {
@@ -1294,6 +2153,32 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -1307,6 +2192,110 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -1366,6 +2355,50 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -1377,6 +2410,67 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -1419,6 +2513,194 @@
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workerd": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -5,15 +5,18 @@
   "main": "index.js",
   "scripts": {
     "dev": "wrangler dev",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "module",
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.12.3",
     "@cloudflare/workers-types": "^4.20260501.1",
     "typescript": "^6.0.3",
+    "vitest": "^3.2.4",
     "wrangler": "^4.87.0"
   }
 }

--- a/worker/src/api-handlers.ts
+++ b/worker/src/api-handlers.ts
@@ -26,11 +26,41 @@ import {
   type RunHealthSummary,
   RULE_CONFIG_DEFAULTS,
 } from './types';
-import { fetchActiveCampaigns, fetchCampaignInsights } from './meta-api-client';
+import { fetchActiveCampaigns, fetchAdAccounts, fetchCampaignInsights } from './meta-api-client';
 
 
 const RULE_CONFIG_KEY = 'RULE_CONFIG';
 const RULE_LOGS_KEY = 'RULE_LOGS';
+
+function getNamespacedKvKey(baseKey: string, accountId: string): string {
+  return `${baseKey}::${accountId}`;
+}
+
+function getRequiredAccountId(req: Request): string | Response {
+  const accountId = new URL(req.url).searchParams.get('accountId')?.trim();
+
+  if (!accountId) {
+    return jsonError(
+      {
+        category: 'validation',
+        code: 'MISSING_ACCOUNT_ID',
+        message: 'accountId query parameter is required.',
+        retryable: false,
+      },
+      { status: 400 }
+    );
+  }
+
+  return accountId.startsWith('act_') ? accountId.slice(4) : accountId;
+}
+
+function getConfigKey(accountId: string): string {
+  return getNamespacedKvKey(RULE_CONFIG_KEY, accountId);
+}
+
+function getLogsKey(accountId: string): string {
+  return getNamespacedKvKey(RULE_LOGS_KEY, accountId);
+}
 
 interface MetaActionRecord {
   action_type?: string;
@@ -780,12 +810,40 @@ function createDefaultRunHealth(): RunHealthSummary {
   };
 }
 
-export async function handleGetCampaigns(_req: Request, env: Env): Promise<Response> {
-  const configRaw = await env.CONFIG_KV.get(RULE_CONFIG_KEY, 'json');
+export async function handleGetAdAccounts(_req: Request, env: Env): Promise<Response> {
+  try {
+    const accounts = await fetchAdAccounts(env);
+
+    return jsonSuccess(accounts, {
+      meta: { total: accounts.length },
+    });
+  } catch (error: unknown) {
+    return jsonError(
+      {
+        category: 'auth',
+        code: 'AD_ACCOUNTS_FETCH_FAILED',
+        message: getErrorMessage(error),
+        retryable: true,
+      },
+      {
+        status: 502,
+        meta: { total: 0 },
+      }
+    );
+  }
+}
+
+export async function handleGetCampaigns(req: Request, env: Env): Promise<Response> {
+  const accountId = getRequiredAccountId(req);
+  if (typeof accountId !== 'string') {
+    return accountId;
+  }
+
+  const configRaw = await env.CONFIG_KV.get(getConfigKey(accountId), 'json');
   const config = normalizeConfig(configRaw);
 
   try {
-    const campaignsRaw = (await fetchActiveCampaigns(env)) as unknown;
+    const campaignsRaw = (await fetchActiveCampaigns(env, accountId)) as unknown;
     const campaigns = Array.isArray(campaignsRaw) ? (campaignsRaw as MetaCampaignRecord[]) : [];
 
     const rows = await Promise.all(
@@ -914,8 +972,13 @@ export async function handleGetCampaignInsights(
   }
 }
 
-export async function handleGetConfig(_req: Request, env: Env): Promise<Response> {
-  const configRaw = await env.CONFIG_KV.get(RULE_CONFIG_KEY, 'json');
+export async function handleGetConfig(req: Request, env: Env): Promise<Response> {
+  const accountId = getRequiredAccountId(req);
+  if (typeof accountId !== 'string') {
+    return accountId;
+  }
+
+  const configRaw = await env.CONFIG_KV.get(getConfigKey(accountId), 'json');
   const config = normalizeConfig(configRaw);
 
   return jsonSuccess(config, {
@@ -924,6 +987,11 @@ export async function handleGetConfig(_req: Request, env: Env): Promise<Response
 }
 
 export async function handlePutConfig(req: Request, env: Env): Promise<Response> {
+  const accountId = getRequiredAccountId(req);
+  if (typeof accountId !== 'string') {
+    return accountId;
+  }
+
   let body: unknown;
 
   try {
@@ -947,7 +1015,7 @@ export async function handlePutConfig(req: Request, env: Env): Promise<Response>
     });
   }
 
-  const currentConfig = normalizeConfig(await env.CONFIG_KV.get(RULE_CONFIG_KEY, 'json'));
+  const currentConfig = normalizeConfig(await env.CONFIG_KV.get(getConfigKey(accountId), 'json'));
   const payload = body as ConfigWriteRequest;
   const submittedVersion = typeof payload.version === 'number' ? payload.version : null;
 
@@ -1004,7 +1072,7 @@ export async function handlePutConfig(req: Request, env: Env): Promise<Response>
     );
   }
 
-  await env.CONFIG_KV.put(RULE_CONFIG_KEY, JSON.stringify(nextConfig));
+  await env.CONFIG_KV.put(getConfigKey(accountId), JSON.stringify(nextConfig));
   await persistConfigVersion(env.AUDIT_DB, {
     version: nextVersion,
     configJson: JSON.stringify(nextConfig),
@@ -1023,8 +1091,13 @@ export async function handlePutConfig(req: Request, env: Env): Promise<Response>
   });
 }
 
-export async function handleGetLogs(_req: Request, env: Env): Promise<Response> {
-  const logsRaw = await env.CONFIG_KV.get(RULE_LOGS_KEY, 'json');
+export async function handleGetLogs(req: Request, env: Env): Promise<Response> {
+  const accountId = getRequiredAccountId(req);
+  if (typeof accountId !== 'string') {
+    return accountId;
+  }
+
+  const logsRaw = await env.CONFIG_KV.get(getLogsKey(accountId), 'json');
   const logs = Array.isArray(logsRaw)
     ? logsRaw
         .map((log, index) => mapStoredLog(log, index))

--- a/worker/src/api-handlers.ts
+++ b/worker/src/api-handlers.ts
@@ -1,112 +1,1114 @@
-import { Env, RuleConfig } from './types';
+import {
+  type ActionLogEntry,
+  type ApiErrorResponse,
+  type ApiResponseMeta,
+  type ApiSuccessResponse,
+  type ApiValidationErrorDetail,
+  type BlockerReason,
+  type CampaignDecisionRow,
+  type CampaignInsightsSummary,
+  type CampaignSnapshot,
+  type CampaignStatus,
+  type ClassifiedError,
+  type ConfigReadModel,
+  type ConfigVersionConflictPayload,
+  type ConfigWriteBlockedPayload,
+  type ConfigWriteSuccessPayload,
+  type DataState,
+  type DataWarning,
+  type DecisionEvidence,
+  type DecisionType,
+  type Env,
+  type HealthPayload,
+  type NormalizedRuleConfig,
+  type RuleAction,
+  type RuleConfig,
+  type RunHealthSummary,
+  RULE_CONFIG_DEFAULTS,
+} from './types';
 import { fetchActiveCampaigns, fetchCampaignInsights } from './meta-api-client';
 
-const DEFAULT_CONFIG: RuleConfig = {
-  pauseThreshold: 170000,
-  pauseThreshold2: 200000,
-  resumeThreshold: 155000,
-  enabled: true
-};
 
-function jsonResponse(data: any, status = 200): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { 'Content-Type': 'application/json' }
+const RULE_CONFIG_KEY = 'RULE_CONFIG';
+const RULE_LOGS_KEY = 'RULE_LOGS';
+
+interface MetaActionRecord {
+  action_type?: string;
+  value?: string;
+}
+
+interface MetaInsightsRecord {
+  spend?: string;
+  actions?: MetaActionRecord[];
+}
+
+interface MetaCampaignRecord {
+  id?: string;
+  name?: string;
+  status?: string;
+}
+
+interface ConfigWriteRequest extends RuleConfig {
+  version?: number | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function isClassifiedError(value: unknown): value is ClassifiedError {
+  return (
+    isRecord(value) &&
+    typeof value.category === 'string' &&
+    typeof value.code === 'string' &&
+    typeof value.message === 'string' &&
+    typeof value.retryable === 'boolean'
+  );
+}
+
+function isDecisionEvidence(value: unknown): value is DecisionEvidence {
+  return (
+    isRecord(value) &&
+    'spendToday' in value &&
+    'purchasesToday' in value &&
+    'purchases3d' in value &&
+    value.purchaseMetric === 'omni_purchase' &&
+    typeof value.dataState === 'string' &&
+    typeof value.dryRun === 'boolean' &&
+    typeof value.cooldownHours === 'number' &&
+    typeof value.maxActionsPerRun === 'number' &&
+    typeof value.maxActionsPerDay === 'number' &&
+    typeof value.allowlisted === 'boolean' &&
+    typeof value.excluded === 'boolean' &&
+    typeof value.emergencyStop === 'boolean' &&
+    typeof value.armingStatus === 'string'
+  );
+}
+
+function isLegacyRuleAction(value: unknown): value is RuleAction {
+  return (
+    isRecord(value) &&
+    typeof value.campaignId === 'string' &&
+    typeof value.campaignName === 'string' &&
+    (value.action === 'PAUSE' || value.action === 'RESUME') &&
+    typeof value.reason === 'string' &&
+    typeof value.timestamp === 'string' &&
+    typeof value.spend === 'number' &&
+    typeof value.purchaseCount === 'number'
+  );
+}
+
+function asBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function asNullableNumber(value: unknown, fallback: number | null): number | null {
+  if (value === null) {
+    return null;
+  }
+
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function asStringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function getNowIso(): string {
+  return new Date().toISOString();
+}
+
+async function persistConfigVersion(
+  db: D1Database | undefined,
+  input: {
+    version: number;
+    configJson: string;
+    createdAt: string;
+    createdBy: string | null;
+  }
+): Promise<void> {
+  if (!db) {
+    return;
+  }
+
+  await db
+    .prepare('INSERT INTO config_versions (version, configJson, createdAt, createdBy) VALUES (?, ?, ?, ?)')
+    .bind(input.version, input.configJson, input.createdAt, input.createdBy)
+    .run();
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return 'Unexpected error';
+}
+
+function buildMeta(meta?: Partial<ApiResponseMeta>): ApiResponseMeta {
+  return {
+    generatedAt: getNowIso(),
+    ...meta,
+  };
+}
+
+function jsonSuccess<T>(
+  data: T,
+  options?: {
+    status?: number;
+    message?: string;
+    meta?: Partial<ApiResponseMeta>;
+    legacy?: Record<string, unknown>;
+  }
+): Response {
+  const payload: ApiSuccessResponse<T> & Record<string, unknown> = {
+    success: true,
+    data,
+    error: null,
+    meta: buildMeta(options?.meta),
+    ...options?.legacy,
+  };
+
+  if (options?.message) {
+    payload.message = options.message;
+  }
+
+  return new Response(JSON.stringify(payload), {
+    status: options?.status ?? 200,
+    headers: { 'Content-Type': 'application/json' },
   });
 }
 
-export async function handleGetCampaigns(req: Request, env: Env): Promise<Response> {
-  const campaigns = await fetchActiveCampaigns(env);
-  
-  // Enrich with today's insights
-  const enrichedCampaigns = await Promise.all(
-    campaigns.map(async (c: any) => {
-      try {
-        const insights = await fetchCampaignInsights(env, c.id);
-        const spend = parseFloat(insights.spend || '0');
-        // Need to extract purchases here or return raw actions
-        const actions = insights.actions || [];
-        const purchaseAction = actions.find((a: any) => a.action_type === 'omni_purchase') || 
-                               actions.find((a: any) => a.action_type === 'purchase');
-        const purchases = purchaseAction ? parseInt(purchaseAction.value, 10) : 0;
-        
-        return {
-          ...c,
-          insights: {
-            spend,
-            purchases
-          }
-        };
-      } catch (err) {
-        return { ...c, insights: null, error: 'Failed to load insights' };
-      }
-    })
-  );
-  
-  return jsonResponse({ data: enrichedCampaigns });
-}
-
-export async function handleGetCampaignInsights(req: Request, env: Env, params: Record<string, string>): Promise<Response> {
-  const { id } = params;
-  if (!id) return jsonResponse({ error: 'Missing campaign id' }, 400);
-  
-  const insights = await fetchCampaignInsights(env, id);
-  return jsonResponse({ data: insights });
-}
-
-export async function handleGetConfig(req: Request, env: Env): Promise<Response> {
-  const configRaw = await env.CONFIG_KV.get('RULE_CONFIG', 'json') as Partial<RuleConfig> | null;
-  const mergedConfig: RuleConfig = {
-    pauseThreshold: configRaw?.pauseThreshold || DEFAULT_CONFIG.pauseThreshold,
-    pauseThreshold2: configRaw?.pauseThreshold2 || DEFAULT_CONFIG.pauseThreshold2,
-    resumeThreshold: configRaw?.resumeThreshold || DEFAULT_CONFIG.resumeThreshold,
-    enabled: configRaw?.enabled ?? DEFAULT_CONFIG.enabled
+function jsonError(
+  error: ClassifiedError,
+  options?: {
+    status?: number;
+    message?: string;
+    data?: unknown;
+    meta?: Partial<ApiResponseMeta>;
+    legacy?: Record<string, unknown>;
+  }
+): Response {
+  const payload: ApiErrorResponse<unknown> & Record<string, unknown> = {
+    success: false,
+    data: options?.data ?? null,
+    error,
+    message: options?.message ?? error.message,
+    meta: buildMeta(options?.meta),
+    ...options?.legacy,
   };
-  return jsonResponse({ data: mergedConfig });
+
+  return new Response(JSON.stringify(payload), {
+    status: options?.status ?? 500,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function buildValidationError(details: ApiValidationErrorDetail[]): ClassifiedError {
+  return {
+    category: 'validation',
+    code: 'INVALID_CONFIG',
+    message: 'Config validation failed',
+    retryable: false,
+    details,
+  };
+}
+
+function buildArmingBlockers(config: NormalizedRuleConfig): BlockerReason[] {
+  const blockers: BlockerReason[] = [];
+
+  if (config.emergencyStop) {
+    blockers.push({
+      code: 'EMERGENCY_STOP',
+      message: 'Emergency stop is enabled.',
+      blocking: true,
+    });
+  }
+
+  if (!config.arming.adAccountConfirmed) {
+    blockers.push({
+      code: 'AD_ACCOUNT_CONFIRMATION_REQUIRED',
+      message: 'Ad account confirmation is required before live mode.',
+      blocking: true,
+    });
+  }
+
+  if (config.allowlistCampaignIds.length === 0) {
+    blockers.push({
+      code: 'ALLOWLIST_REQUIRED',
+      message: 'At least one allowlisted campaign is required before live mode.',
+      blocking: true,
+    });
+  }
+
+  if (config.maxActionsPerRun <= 0 || config.maxActionsPerDay <= 0) {
+    blockers.push({
+      code: 'ACTION_CAPS_REQUIRED',
+      message: 'Positive action caps are required before live mode.',
+      blocking: true,
+    });
+  }
+
+  if (!config.arming.recentDryRunReviewedAt) {
+    blockers.push({
+      code: 'RECENT_DRY_RUN_REVIEW_REQUIRED',
+      message: 'A reviewed recent dry-run is required before live mode.',
+      blocking: true,
+    });
+  }
+
+  return blockers;
+}
+
+function normalizeConfig(input: unknown): ConfigReadModel {
+  const record = isRecord(input) ? input : {};
+  const armingRecord = isRecord(record.arming) ? record.arming : {};
+
+  const config: ConfigReadModel = {
+    enabled: asBoolean(record.enabled, RULE_CONFIG_DEFAULTS.enabled),
+    dryRun: asBoolean(record.dryRun, RULE_CONFIG_DEFAULTS.dryRun),
+    pauseThreshold: asNumber(record.pauseThreshold, RULE_CONFIG_DEFAULTS.pauseThreshold),
+    pauseThreshold2: asNullableNumber(record.pauseThreshold2, RULE_CONFIG_DEFAULTS.pauseThreshold2),
+    resumeThreshold: asNumber(record.resumeThreshold, RULE_CONFIG_DEFAULTS.resumeThreshold),
+    cooldownHours: asNumber(record.cooldownHours, RULE_CONFIG_DEFAULTS.cooldownHours),
+    maxActionsPerRun: asNumber(record.maxActionsPerRun, RULE_CONFIG_DEFAULTS.maxActionsPerRun),
+    maxActionsPerDay: asNumber(record.maxActionsPerDay, RULE_CONFIG_DEFAULTS.maxActionsPerDay),
+    allowlistCampaignIds: isStringArray(record.allowlistCampaignIds)
+      ? [...record.allowlistCampaignIds]
+      : [...RULE_CONFIG_DEFAULTS.allowlistCampaignIds],
+    excludeCampaignIds: isStringArray(record.excludeCampaignIds)
+      ? [...record.excludeCampaignIds]
+      : [...RULE_CONFIG_DEFAULTS.excludeCampaignIds],
+    emergencyStop: asBoolean(record.emergencyStop, RULE_CONFIG_DEFAULTS.emergencyStop),
+    arming: {
+      status:
+        armingRecord.status === 'eligible' ||
+        armingRecord.status === 'armed' ||
+        armingRecord.status === 'blocked'
+          ? armingRecord.status
+          : RULE_CONFIG_DEFAULTS.arming.status,
+      adAccountConfirmed: asBoolean(
+        armingRecord.adAccountConfirmed,
+        RULE_CONFIG_DEFAULTS.arming.adAccountConfirmed
+      ),
+      recentDryRunRunId: asStringOrNull(armingRecord.recentDryRunRunId),
+      recentDryRunReviewedAt: asStringOrNull(armingRecord.recentDryRunReviewedAt),
+      reviewedBy: asStringOrNull(armingRecord.reviewedBy),
+      reliabilityScore:
+        typeof armingRecord.reliabilityScore === 'number' && Number.isFinite(armingRecord.reliabilityScore)
+          ? armingRecord.reliabilityScore
+          : RULE_CONFIG_DEFAULTS.arming.reliabilityScore,
+      evidenceWindowDays: asNumber(
+        armingRecord.evidenceWindowDays,
+        RULE_CONFIG_DEFAULTS.arming.evidenceWindowDays
+      ),
+    },
+    version:
+      typeof record.version === 'number' && Number.isFinite(record.version) ? record.version : null,
+    updatedAt: asStringOrNull(record.updatedAt),
+    updatedBy: asStringOrNull(record.updatedBy),
+    liveArmingEligible: false,
+    armingBlockers: [],
+  };
+
+  const armingBlockers = buildArmingBlockers(config);
+
+  return {
+    ...config,
+    armingBlockers,
+    liveArmingEligible: armingBlockers.length === 0,
+  };
+}
+
+function validateConfigInput(input: unknown): ApiValidationErrorDetail[] {
+  if (!isRecord(input)) {
+    return [
+      {
+        field: 'body',
+        code: 'invalid_type',
+        message: 'Config payload must be an object.',
+      },
+    ];
+  }
+
+  const details: ApiValidationErrorDetail[] = [];
+
+  const pushIfInvalidNumber = (field: string, value: unknown, allowNull = false) => {
+    if (allowNull && value === null) {
+      return;
+    }
+
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+      details.push({
+        field,
+        code: 'invalid_number',
+        message: `${field} must be a finite number greater than or equal to 0.`,
+      });
+    }
+  };
+
+  if (typeof input.enabled !== 'boolean') {
+    details.push({
+      field: 'enabled',
+      code: 'invalid_type',
+      message: 'enabled must be a boolean.',
+    });
+  }
+
+  if (typeof input.dryRun !== 'boolean') {
+    details.push({
+      field: 'dryRun',
+      code: 'invalid_type',
+      message: 'dryRun must be a boolean.',
+    });
+  }
+
+  if (typeof input.emergencyStop !== 'boolean') {
+    details.push({
+      field: 'emergencyStop',
+      code: 'invalid_type',
+      message: 'emergencyStop must be a boolean.',
+    });
+  }
+
+  pushIfInvalidNumber('pauseThreshold', input.pauseThreshold);
+  pushIfInvalidNumber('pauseThreshold2', input.pauseThreshold2, true);
+  pushIfInvalidNumber('resumeThreshold', input.resumeThreshold);
+
+  if (
+    typeof input.cooldownHours !== 'number' ||
+    !Number.isFinite(input.cooldownHours) ||
+    input.cooldownHours <= 0
+  ) {
+    details.push({
+      field: 'cooldownHours',
+      code: 'invalid_number',
+      message: 'cooldownHours must be a finite number greater than 0.',
+    });
+  }
+
+  if (
+    typeof input.maxActionsPerRun !== 'number' ||
+    !Number.isInteger(input.maxActionsPerRun) ||
+    input.maxActionsPerRun < 0
+  ) {
+    details.push({
+      field: 'maxActionsPerRun',
+      code: 'invalid_number',
+      message: 'maxActionsPerRun must be an integer greater than or equal to 0.',
+    });
+  }
+
+  if (
+    typeof input.maxActionsPerDay !== 'number' ||
+    !Number.isInteger(input.maxActionsPerDay) ||
+    input.maxActionsPerDay < 0
+  ) {
+    details.push({
+      field: 'maxActionsPerDay',
+      code: 'invalid_number',
+      message: 'maxActionsPerDay must be an integer greater than or equal to 0.',
+    });
+  }
+
+  if (!isStringArray(input.allowlistCampaignIds)) {
+    details.push({
+      field: 'allowlistCampaignIds',
+      code: 'invalid_type',
+      message: 'allowlistCampaignIds must be an array of campaign ids.',
+    });
+  }
+
+  if (!isStringArray(input.excludeCampaignIds)) {
+    details.push({
+      field: 'excludeCampaignIds',
+      code: 'invalid_type',
+      message: 'excludeCampaignIds must be an array of campaign ids.',
+    });
+  }
+
+  if (!isRecord(input.arming)) {
+    details.push({
+      field: 'arming',
+      code: 'invalid_type',
+      message: 'arming must be an object.',
+    });
+  } else {
+    if (typeof input.arming.adAccountConfirmed !== 'boolean') {
+      details.push({
+        field: 'arming.adAccountConfirmed',
+        code: 'invalid_type',
+        message: 'arming.adAccountConfirmed must be a boolean.',
+      });
+    }
+
+    if (
+      input.arming.reliabilityScore !== null &&
+      input.arming.reliabilityScore !== undefined &&
+      (typeof input.arming.reliabilityScore !== 'number' || !Number.isFinite(input.arming.reliabilityScore))
+    ) {
+      details.push({
+        field: 'arming.reliabilityScore',
+        code: 'invalid_number',
+        message: 'arming.reliabilityScore must be a finite number or null.',
+      });
+    }
+
+    if (
+      typeof input.arming.evidenceWindowDays !== 'number' ||
+      !Number.isInteger(input.arming.evidenceWindowDays) ||
+      input.arming.evidenceWindowDays <= 0
+    ) {
+      details.push({
+        field: 'arming.evidenceWindowDays',
+        code: 'invalid_number',
+        message: 'arming.evidenceWindowDays must be a positive integer.',
+      });
+    }
+  }
+
+  return details;
+}
+
+function normalizeCampaignStatus(value: unknown): CampaignStatus {
+  return value === 'PAUSED' ? 'PAUSED' : 'ACTIVE';
+}
+
+function extractInsightsSummary(raw: unknown): {
+  insights: CampaignInsightsSummary;
+  warnings: DataWarning[];
+  purchases: number | null;
+} {
+  const record = isRecord(raw) ? (raw as MetaInsightsRecord) : {};
+  const spend = typeof record.spend === 'string' ? Number.parseFloat(record.spend) : 0;
+  const actions = Array.isArray(record.actions) ? record.actions : [];
+  const omniPurchase = actions.find((action) => action.action_type === 'omni_purchase');
+  const hasPurchaseMetric = Boolean(omniPurchase);
+  const purchases =
+    hasPurchaseMetric && typeof omniPurchase?.value === 'string'
+      ? Number.parseInt(omniPurchase.value, 10)
+      : 0;
+  const warnings: DataWarning[] = [];
+  const dataState: DataState = hasPurchaseMetric ? 'complete' : 'missing';
+
+  if (!hasPurchaseMetric) {
+    warnings.push({
+      code: 'MISSING_OMNI_PURCHASE',
+      message: 'Meta insights payload does not include omni_purchase.',
+      severity: 'warning',
+    });
+  }
+
+  return {
+    insights: {
+      spend: Number.isFinite(spend) ? spend : 0,
+      purchases,
+      purchaseMetric: 'omni_purchase',
+      hasPurchaseMetric,
+      dataState,
+    },
+    warnings,
+    purchases: hasPurchaseMetric ? purchases : null,
+  };
+}
+
+function createEvidence(config: ConfigReadModel, campaignId: string, insights: CampaignInsightsSummary): DecisionEvidence {
+  return {
+    spendToday: insights.spend,
+    purchasesToday: insights.hasPurchaseMetric ? insights.purchases : null,
+    purchases3d: null,
+    purchaseMetric: 'omni_purchase',
+    dataState: insights.dataState,
+    dryRun: config.dryRun,
+    cooldownHours: config.cooldownHours,
+    maxActionsPerRun: config.maxActionsPerRun,
+    maxActionsPerDay: config.maxActionsPerDay,
+    allowlisted: config.allowlistCampaignIds.includes(campaignId),
+    excluded: config.excludeCampaignIds.includes(campaignId),
+    emergencyStop: config.emergencyStop,
+    armingStatus: config.arming.status,
+    reliabilityScore: config.arming.reliabilityScore,
+  };
+}
+
+function determineDecision(
+  campaign: MetaCampaignRecord,
+  config: ConfigReadModel,
+  insights: CampaignInsightsSummary,
+  warnings: DataWarning[]
+): {
+  decision: DecisionType;
+  why: string[];
+  blockers: BlockerReason[];
+} {
+  if (!insights.hasPurchaseMetric) {
+    return {
+      decision: 'UNKNOWN_DATA',
+      why: ['Cannot make trusted decision without omni_purchase.'],
+      blockers: [
+        {
+          code: 'MISSING_OMNI_PURCHASE',
+          message: 'Missing omni_purchase blocks trusted automation decisions.',
+          blocking: true,
+        },
+      ],
+    };
+  }
+
+  const status = normalizeCampaignStatus(campaign.status);
+  const spend = insights.spend;
+  const purchases = insights.purchases;
+  const liveBlockers = buildArmingBlockers(config);
+
+  if (config.excludeCampaignIds.includes(campaign.id ?? '')) {
+    return {
+      decision: 'SKIPPED_CAP',
+      why: ['Campaign is excluded from automation.'],
+      blockers: [
+        {
+          code: 'CAMPAIGN_EXCLUDED',
+          message: 'Campaign is in exclusion list.',
+          blocking: true,
+        },
+      ],
+    };
+  }
+
+  if (!config.dryRun && !config.allowlistCampaignIds.includes(campaign.id ?? '')) {
+    return {
+      decision: 'BLOCKED_NOT_ARMED',
+      why: ['Campaign is not allowlisted for live automation.'],
+      blockers: [
+        {
+          code: 'CAMPAIGN_NOT_ALLOWED',
+          message: 'Campaign is not present in allowlist.',
+          blocking: true,
+        },
+      ],
+    };
+  }
+
+  if (status === 'ACTIVE' && spend > config.pauseThreshold && purchases === 0) {
+    if (config.dryRun) {
+      return {
+        decision: 'WOULD_PAUSE',
+        why: [`Spend ${spend} is above pause threshold ${config.pauseThreshold} with 0 omni_purchase.`],
+        blockers: liveBlockers,
+      };
+    }
+
+    if (liveBlockers.length > 0) {
+      return {
+        decision: 'BLOCKED_NOT_ARMED',
+        why: ['Live pause is blocked until arming requirements pass.'],
+        blockers: liveBlockers,
+      };
+    }
+
+    return {
+      decision: 'PAUSE',
+      why: [`Spend ${spend} is above pause threshold ${config.pauseThreshold} with 0 omni_purchase.`],
+      blockers: [],
+    };
+  }
+
+  if (
+    status === 'ACTIVE' &&
+    config.pauseThreshold2 !== null &&
+    spend > config.pauseThreshold2 &&
+    purchases < 2
+  ) {
+    if (config.dryRun) {
+      return {
+        decision: 'WOULD_PAUSE',
+        why: [`Spend ${spend} is above pause threshold 2 ${config.pauseThreshold2} with fewer than 2 omni_purchase.`],
+        blockers: liveBlockers,
+      };
+    }
+
+    if (liveBlockers.length > 0) {
+      return {
+        decision: 'BLOCKED_NOT_ARMED',
+        why: ['Live pause is blocked until arming requirements pass.'],
+        blockers: liveBlockers,
+      };
+    }
+
+    return {
+      decision: 'PAUSE',
+      why: [`Spend ${spend} is above pause threshold 2 ${config.pauseThreshold2} with fewer than 2 omni_purchase.`],
+      blockers: [],
+    };
+  }
+
+  if (status === 'PAUSED' && spend < config.resumeThreshold && purchases > 0) {
+    if (config.dryRun) {
+      return {
+        decision: 'WOULD_RESUME',
+        why: [`Spend ${spend} is below resume threshold ${config.resumeThreshold} with ${purchases} omni_purchase.`],
+        blockers: liveBlockers,
+      };
+    }
+
+    if (liveBlockers.length > 0) {
+      return {
+        decision: 'BLOCKED_NOT_ARMED',
+        why: ['Live resume is blocked until arming requirements pass.'],
+        blockers: liveBlockers,
+      };
+    }
+
+    return {
+      decision: 'RESUME',
+      why: [`Spend ${spend} is below resume threshold ${config.resumeThreshold} with ${purchases} omni_purchase.`],
+      blockers: [],
+    };
+  }
+
+  return {
+    decision: warnings.length > 0 ? 'UNKNOWN_DATA' : 'MONITORING',
+    why: warnings.length > 0 ? ['Monitoring blocked by incomplete decision evidence.'] : ['Campaign is being monitored.'],
+    blockers: [],
+  };
+}
+
+function createCampaignSnapshot(
+  campaign: MetaCampaignRecord,
+  insights: CampaignInsightsSummary,
+  purchases: number | null
+): CampaignSnapshot {
+  return {
+    id: typeof campaign.id === 'string' ? campaign.id : '',
+    name: typeof campaign.name === 'string' ? campaign.name : 'Unknown campaign',
+    status: normalizeCampaignStatus(campaign.status),
+    spendToday: insights.spend,
+    purchasesToday: purchases,
+    purchases3d: null,
+    purchaseMetric: 'omni_purchase',
+    hasPurchaseMetric: insights.hasPurchaseMetric,
+    dataState: insights.dataState,
+  };
+}
+
+function mapLegacyLog(log: RuleAction, index: number): ActionLogEntry {
+  const decision = log.action === 'PAUSE' ? 'PAUSE' : 'RESUME';
+
+  return {
+    id: `${log.timestamp}-${log.campaignId}-${index}`,
+    runId: null,
+    campaignId: log.campaignId,
+    campaignName: log.campaignName,
+    decision,
+    source: 'live',
+    status: 'applied',
+    occurredAt: log.timestamp,
+    why: [log.reason],
+    blockers: [],
+    warnings: [],
+    error: null,
+    evidence: {
+      spendToday: log.spend,
+      purchasesToday: log.purchaseCount,
+      purchases3d: null,
+      purchaseMetric: 'omni_purchase',
+      dataState: 'complete',
+      dryRun: false,
+      cooldownHours: RULE_CONFIG_DEFAULTS.cooldownHours,
+      maxActionsPerRun: RULE_CONFIG_DEFAULTS.maxActionsPerRun,
+      maxActionsPerDay: RULE_CONFIG_DEFAULTS.maxActionsPerDay,
+      allowlisted: true,
+      excluded: false,
+      emergencyStop: false,
+      armingStatus: 'armed',
+      reliabilityScore: null,
+    },
+  };
+}
+
+function mapStoredLog(log: unknown, index: number): ActionLogEntry | null {
+  if (!isRecord(log)) {
+    return null;
+  }
+
+  if ('decision' in log && 'occurredAt' in log) {
+    return {
+      id: typeof log.id === 'string' ? log.id : `timeline-${index}`,
+      runId: typeof log.runId === 'string' ? log.runId : null,
+      campaignId: typeof log.campaignId === 'string' ? log.campaignId : null,
+      campaignName: typeof log.campaignName === 'string' ? log.campaignName : null,
+      decision:
+        typeof log.decision === 'string'
+          ? (log.decision as ActionLogEntry['decision'])
+          : 'ERROR',
+      source:
+        log.source === 'dry_run' || log.source === 'system' ? log.source : 'live',
+      status:
+        log.status === 'skipped' || log.status === 'failed' ? log.status : 'applied',
+      occurredAt: typeof log.occurredAt === 'string' ? log.occurredAt : getNowIso(),
+      why: Array.isArray(log.why) ? log.why.filter((item): item is string => typeof item === 'string') : [],
+      blockers: Array.isArray(log.blockers) ? (log.blockers as BlockerReason[]) : [],
+      warnings: Array.isArray(log.warnings) ? (log.warnings as DataWarning[]) : [],
+      error: isClassifiedError(log.error) ? log.error : null,
+      evidence: isDecisionEvidence(log.evidence) ? log.evidence : null,
+    };
+  }
+
+  if (isLegacyRuleAction(log)) {
+    return mapLegacyLog(log, index);
+  }
+
+  return null;
+}
+
+function createDefaultRunHealth(): RunHealthSummary {
+  return {
+    currentStatus: null,
+    lastStartedAt: null,
+    lastCompletedAt: null,
+    lastFailedAt: null,
+    nextScheduledAt: null,
+    activeLock: false,
+    activeRunId: null,
+  };
+}
+
+export async function handleGetCampaigns(_req: Request, env: Env): Promise<Response> {
+  const configRaw = await env.CONFIG_KV.get(RULE_CONFIG_KEY, 'json');
+  const config = normalizeConfig(configRaw);
+
+  try {
+    const campaignsRaw = (await fetchActiveCampaigns(env)) as unknown;
+    const campaigns = Array.isArray(campaignsRaw) ? (campaignsRaw as MetaCampaignRecord[]) : [];
+
+    const rows = await Promise.all(
+      campaigns.map(async (campaign): Promise<CampaignDecisionRow> => {
+        try {
+          const insightsRaw = await fetchCampaignInsights(env, typeof campaign.id === 'string' ? campaign.id : '');
+          const { insights, warnings, purchases } = extractInsightsSummary(insightsRaw);
+          const decisionResult = determineDecision(campaign, config, insights, warnings);
+          const evidence = createEvidence(config, typeof campaign.id === 'string' ? campaign.id : '', insights);
+
+          return {
+            id: typeof campaign.id === 'string' ? campaign.id : '',
+            name: typeof campaign.name === 'string' ? campaign.name : 'Unknown campaign',
+            status: normalizeCampaignStatus(campaign.status),
+            decision: decisionResult.decision,
+            why: decisionResult.why,
+            evidence,
+            blockers: decisionResult.blockers,
+            campaignSnapshot: createCampaignSnapshot(campaign, insights, purchases),
+            warnings,
+            error: null,
+            insights,
+          };
+        } catch (error: unknown) {
+          const message = getErrorMessage(error);
+          const classifiedError: ClassifiedError = {
+            category: 'global_insights',
+            code: 'INSIGHTS_FETCH_FAILED',
+            message,
+            retryable: true,
+          };
+
+          return {
+            id: typeof campaign.id === 'string' ? campaign.id : '',
+            name: typeof campaign.name === 'string' ? campaign.name : 'Unknown campaign',
+            status: normalizeCampaignStatus(campaign.status),
+            decision: 'ERROR',
+            why: ['Insights fetch failed for this campaign.'],
+            evidence: {
+              spendToday: null,
+              purchasesToday: null,
+              purchases3d: null,
+              purchaseMetric: 'omni_purchase',
+              dataState: 'error',
+              dryRun: config.dryRun,
+              cooldownHours: config.cooldownHours,
+              maxActionsPerRun: config.maxActionsPerRun,
+              maxActionsPerDay: config.maxActionsPerDay,
+              allowlisted: config.allowlistCampaignIds.includes(typeof campaign.id === 'string' ? campaign.id : ''),
+              excluded: config.excludeCampaignIds.includes(typeof campaign.id === 'string' ? campaign.id : ''),
+              emergencyStop: config.emergencyStop,
+              armingStatus: config.arming.status,
+              reliabilityScore: config.arming.reliabilityScore,
+            },
+            blockers: [],
+            campaignSnapshot: {
+              id: typeof campaign.id === 'string' ? campaign.id : '',
+              name: typeof campaign.name === 'string' ? campaign.name : 'Unknown campaign',
+              status: normalizeCampaignStatus(campaign.status),
+              spendToday: null,
+              purchasesToday: null,
+              purchases3d: null,
+              purchaseMetric: 'omni_purchase',
+              hasPurchaseMetric: false,
+              dataState: 'error',
+            },
+            warnings: [],
+            error: classifiedError,
+            insights: null,
+          };
+        }
+      })
+    );
+
+    return jsonSuccess(rows, {
+      meta: { total: rows.length, run: createDefaultRunHealth() },
+    });
+  } catch (error: unknown) {
+    return jsonError(
+      {
+        category: 'global_insights',
+        code: 'CAMPAIGNS_FETCH_FAILED',
+        message: getErrorMessage(error),
+        retryable: true,
+      },
+      {
+        status: 502,
+        meta: { total: 0, run: createDefaultRunHealth() },
+      }
+    );
+  }
+}
+
+export async function handleGetCampaignInsights(
+  _req: Request,
+  env: Env,
+  params: Record<string, string>
+): Promise<Response> {
+  const { id } = params;
+
+  if (!id) {
+    return jsonError(
+      {
+        category: 'validation',
+        code: 'MISSING_CAMPAIGN_ID',
+        message: 'Missing campaign id',
+        retryable: false,
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const insights = await fetchCampaignInsights(env, id);
+    return jsonSuccess(insights);
+  } catch (error: unknown) {
+    return jsonError(
+      {
+        category: 'global_insights',
+        code: 'INSIGHTS_FETCH_FAILED',
+        message: getErrorMessage(error),
+        retryable: true,
+      },
+      { status: 502 }
+    );
+  }
+}
+
+export async function handleGetConfig(_req: Request, env: Env): Promise<Response> {
+  const configRaw = await env.CONFIG_KV.get(RULE_CONFIG_KEY, 'json');
+  const config = normalizeConfig(configRaw);
+
+  return jsonSuccess(config, {
+    meta: { version: config.version },
+  });
 }
 
 export async function handlePutConfig(req: Request, env: Env): Promise<Response> {
-  let body: any;
+  let body: unknown;
+
   try {
     body = await req.json();
-  } catch (err) {
-    return jsonResponse({ error: 'Invalid JSON' }, 400);
+  } catch {
+    return jsonError(
+      {
+        category: 'validation',
+        code: 'INVALID_JSON',
+        message: 'Invalid JSON',
+        retryable: false,
+      },
+      { status: 400 }
+    );
   }
 
-  // Very basic validation
-  if (typeof body.pauseThreshold !== 'number' || typeof body.resumeThreshold !== 'number') {
-    return jsonResponse({ error: 'Invalid threshold types. Must be numbers.' }, 400);
+  const validationErrors = validateConfigInput(body);
+  if (validationErrors.length > 0) {
+    return jsonError(buildValidationError(validationErrors), {
+      status: 400,
+    });
   }
 
-  const newConfig: RuleConfig = {
-    pauseThreshold: body.pauseThreshold,
-    pauseThreshold2: body.pauseThreshold2 ?? 200000,
-    resumeThreshold: body.resumeThreshold,
-    enabled: typeof body.enabled === 'boolean' ? body.enabled : true
+  const currentConfig = normalizeConfig(await env.CONFIG_KV.get(RULE_CONFIG_KEY, 'json'));
+  const payload = body as ConfigWriteRequest;
+  const submittedVersion = typeof payload.version === 'number' ? payload.version : null;
+
+  if (currentConfig.version !== submittedVersion) {
+    const conflictPayload: ConfigVersionConflictPayload = {
+      status: 'version_conflict',
+      currentVersion: currentConfig.version,
+      submittedVersion,
+      latestConfig: currentConfig,
+    };
+
+    return jsonError(
+      {
+        category: 'config',
+        code: 'CONFIG_VERSION_CONFLICT',
+        message: 'Config version conflict',
+        retryable: true,
+      },
+      {
+        status: 409,
+        data: conflictPayload,
+        meta: { version: currentConfig.version },
+      }
+    );
+  }
+
+  const nextVersion = (currentConfig.version ?? 0) + 1;
+  const nextConfig = normalizeConfig({
+    ...payload,
+    version: nextVersion,
+    updatedAt: getNowIso(),
+    updatedBy: 'dashboard',
+  });
+
+  if (!nextConfig.dryRun && nextConfig.armingBlockers.length > 0) {
+    const blockedPayload: ConfigWriteBlockedPayload = {
+      status: 'blocked_live_gate',
+      config: nextConfig,
+      blockers: nextConfig.armingBlockers,
+    };
+
+    return jsonError(
+      {
+        category: 'config',
+        code: 'LIVE_ARMING_BLOCKED',
+        message: 'Live mode is blocked until arming requirements pass',
+        retryable: false,
+      },
+      {
+        status: 409,
+        data: blockedPayload,
+        meta: { version: currentConfig.version },
+      }
+    );
+  }
+
+  await env.CONFIG_KV.put(RULE_CONFIG_KEY, JSON.stringify(nextConfig));
+  await persistConfigVersion(env.AUDIT_DB, {
+    version: nextVersion,
+    configJson: JSON.stringify(nextConfig),
+    createdAt: nextConfig.updatedAt ?? getNowIso(),
+    createdBy: nextConfig.updatedBy,
+  });
+
+  const successPayload: ConfigWriteSuccessPayload = {
+    status: 'saved',
+    config: nextConfig,
   };
 
-  await env.CONFIG_KV.put('RULE_CONFIG', JSON.stringify(newConfig));
-  return jsonResponse({ data: newConfig, message: 'Config updated successfully' });
+  return jsonSuccess(successPayload, {
+    message: 'Config updated successfully',
+    meta: { version: nextConfig.version },
+  });
 }
 
-export async function handleGetLogs(req: Request, env: Env): Promise<Response> {
-  const logsRaw = await env.CONFIG_KV.get('RULE_LOGS', 'json');
-  return jsonResponse({ data: logsRaw || [] });
+export async function handleGetLogs(_req: Request, env: Env): Promise<Response> {
+  const logsRaw = await env.CONFIG_KV.get(RULE_LOGS_KEY, 'json');
+  const logs = Array.isArray(logsRaw)
+    ? logsRaw
+        .map((log, index) => mapStoredLog(log, index))
+        .filter((log): log is ActionLogEntry => log !== null)
+    : [];
+
+  return jsonSuccess(logs, {
+    meta: { total: logs.length, run: createDefaultRunHealth() },
+  });
 }
 
-export async function handleHealth(req: Request, env: Env): Promise<Response> {
+export async function handleHealth(_req: Request, env: Env): Promise<Response> {
   try {
-    // Quick token test by calling graph api me
-    const url = `https://graph.facebook.com/v21.0/me?access_token=${env.META_ACCESS_TOKEN}`;
-    const response = await fetch(url);
-    const data: any = await response.json();
-    
-    if (data.error) {
-      return jsonResponse({ status: 'error', message: data.error.message }, 401);
+    const url = 'https://graph.facebook.com/v21.0/me';
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${env.META_ACCESS_TOKEN}`,
+      },
+    });
+    const data = (await response.json()) as unknown;
+
+    if (isRecord(data) && isRecord(data.error) && typeof data.error.message === 'string') {
+      const payload: HealthPayload = {
+        status: 'error',
+        message: data.error.message,
+        checkedAt: getNowIso(),
+        metaAccountId: env.META_ACCOUNT_ID,
+      };
+
+      return jsonError(
+        {
+          category: 'auth',
+          code: 'META_TOKEN_INVALID',
+          message: data.error.message,
+          retryable: false,
+        },
+        {
+          status: 401,
+          data: payload,
+          legacy: {
+            status: payload.status,
+            checkedAt: payload.checkedAt,
+          },
+        }
+      );
     }
-    
-    return jsonResponse({ status: 'ok', message: 'System healthy and token valid' });
-  } catch (err: any) {
-    return jsonResponse({ status: 'error', message: err.message }, 500);
+
+    const payload: HealthPayload = {
+      status: 'ok',
+      message: 'System healthy and token valid',
+      checkedAt: getNowIso(),
+      metaAccountId: env.META_ACCOUNT_ID,
+    };
+
+    return jsonSuccess(payload, {
+      legacy: {
+        status: payload.status,
+        checkedAt: payload.checkedAt,
+      },
+    });
+  } catch (error: unknown) {
+    const message = getErrorMessage(error);
+    const payload: HealthPayload = {
+      status: 'error',
+      message,
+      checkedAt: getNowIso(),
+      metaAccountId: env.META_ACCOUNT_ID,
+    };
+
+    return jsonError(
+      {
+        category: 'auth',
+        code: 'HEALTH_CHECK_FAILED',
+        message,
+        retryable: true,
+      },
+      {
+        status: 500,
+        data: payload,
+        legacy: {
+          status: payload.status,
+          checkedAt: payload.checkedAt,
+        },
+      }
+    );
   }
 }

--- a/worker/src/auto-rule-engine.ts
+++ b/worker/src/auto-rule-engine.ts
@@ -1,65 +1,713 @@
-import { Env, RuleConfig, RuleAction } from './types';
-import { 
-  fetchActiveCampaigns, 
-  fetchCampaignInsights, 
-  pauseCampaign, 
-  resumeCampaign, 
-  extractPurchaseCount 
+import {
+  type ActionLogEntry,
+  type BlockerReason,
+  type CampaignDecisionRow,
+  type CampaignInsightsSummary,
+  type CampaignSnapshot,
+  type ClassifiedError,
+  type DataState,
+  type DataWarning,
+  type DecisionEvidence,
+  type DecisionType,
+  type Env,
+  type NormalizedRuleConfig,
+  type RuleAction,
+  type RuleConfig,
+  RULE_CONFIG_DEFAULTS,
+} from './types';
+import {
+  extractPurchaseCount,
+  fetchAccountCampaignInsights,
+  fetchActiveCampaigns,
+  pauseCampaign,
+  resumeCampaign,
+  type MetaAccountInsightsRow,
+  type MetaActionRecord,
+  type MetaCampaignRecord,
 } from './meta-api-client';
+
+interface ExecutionResult {
+  actions: RuleAction[];
+  logs: ActionLogEntry[];
+  campaignStateUpdates: Array<{
+    campaignId: string;
+    lastDecision: DecisionType;
+    lastAction: 'PAUSE' | 'RESUME' | null;
+    lastActionAt: string | null;
+    lastRunId: string | null;
+    pausedByTool: boolean;
+  }>;
+}
+
+interface DecisionInputInsights {
+  summary: CampaignInsightsSummary;
+  warnings: DataWarning[];
+  purchasesToday: number | null;
+  purchases3d: number | null;
+  hasPurchaseMetric3d: boolean;
+}
+
+function getNowIso(): string {
+  return new Date().toISOString();
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return 'Unexpected error';
+}
+
+function normalizeRuleConfig(config: RuleConfig): NormalizedRuleConfig {
+  return {
+    ...RULE_CONFIG_DEFAULTS,
+    ...config,
+    pauseThreshold2: config.pauseThreshold2 ?? RULE_CONFIG_DEFAULTS.pauseThreshold2,
+    cooldownHours: config.cooldownHours ?? RULE_CONFIG_DEFAULTS.cooldownHours,
+    maxActionsPerRun: config.maxActionsPerRun ?? RULE_CONFIG_DEFAULTS.maxActionsPerRun,
+    maxActionsPerDay: config.maxActionsPerDay ?? RULE_CONFIG_DEFAULTS.maxActionsPerDay,
+    allowlistCampaignIds: [...(config.allowlistCampaignIds ?? RULE_CONFIG_DEFAULTS.allowlistCampaignIds)],
+    excludeCampaignIds: [...(config.excludeCampaignIds ?? RULE_CONFIG_DEFAULTS.excludeCampaignIds)],
+    emergencyStop: config.emergencyStop ?? RULE_CONFIG_DEFAULTS.emergencyStop,
+    dryRun: config.dryRun ?? RULE_CONFIG_DEFAULTS.dryRun,
+    arming: {
+      ...RULE_CONFIG_DEFAULTS.arming,
+      ...(config.arming ?? {}),
+    },
+  };
+}
+
+function buildArmingBlockers(config: NormalizedRuleConfig): BlockerReason[] {
+  const blockers: BlockerReason[] = [];
+
+  if (config.emergencyStop) {
+    blockers.push({
+      code: 'EMERGENCY_STOP',
+      message: 'Emergency stop is enabled.',
+      blocking: true,
+    });
+  }
+
+  if (!config.arming.adAccountConfirmed) {
+    blockers.push({
+      code: 'AD_ACCOUNT_CONFIRMATION_REQUIRED',
+      message: 'Ad account confirmation is required before live mode.',
+      blocking: true,
+    });
+  }
+
+  if (config.allowlistCampaignIds.length === 0) {
+    blockers.push({
+      code: 'ALLOWLIST_REQUIRED',
+      message: 'At least one allowlisted campaign is required before live mode.',
+      blocking: true,
+    });
+  }
+
+  if (config.maxActionsPerRun <= 0 || config.maxActionsPerDay <= 0) {
+    blockers.push({
+      code: 'ACTION_CAPS_REQUIRED',
+      message: 'Positive action caps are required before live mode.',
+      blocking: true,
+    });
+  }
+
+  if (!config.arming.recentDryRunReviewedAt) {
+    blockers.push({
+      code: 'RECENT_DRY_RUN_REVIEW_REQUIRED',
+      message: 'A reviewed recent dry-run is required before live mode.',
+      blocking: true,
+    });
+  }
+
+  return blockers;
+}
+
+function createEvidence(
+  config: NormalizedRuleConfig,
+  campaignId: string,
+  insights: CampaignInsightsSummary,
+  purchases3d: number | null
+): DecisionEvidence {
+  return {
+    spendToday: insights.spend,
+    purchasesToday: insights.hasPurchaseMetric ? insights.purchases : null,
+    purchases3d,
+    purchaseMetric: 'omni_purchase',
+    dataState: insights.dataState,
+    dryRun: config.dryRun,
+    cooldownHours: config.cooldownHours,
+    maxActionsPerRun: config.maxActionsPerRun,
+    maxActionsPerDay: config.maxActionsPerDay,
+    allowlisted: config.allowlistCampaignIds.includes(campaignId),
+    excluded: config.excludeCampaignIds.includes(campaignId),
+    emergencyStop: config.emergencyStop,
+    armingStatus: config.arming.status,
+    reliabilityScore: config.arming.reliabilityScore,
+  };
+}
+
+function createCampaignSnapshot(
+  campaign: MetaCampaignRecord,
+  insights: CampaignInsightsSummary,
+  purchasesToday: number | null,
+  purchases3d: number | null
+): CampaignSnapshot {
+  return {
+    id: campaign.id,
+    name: campaign.name,
+    status: campaign.status,
+    spendToday: insights.spend,
+    purchasesToday,
+    purchases3d,
+    purchaseMetric: 'omni_purchase',
+    hasPurchaseMetric: insights.hasPurchaseMetric,
+    dataState: insights.dataState,
+  };
+}
+
+function createInsightsSummary(raw: {
+  spend?: string;
+  actions?: MetaActionRecord[];
+}): {
+  insights: CampaignInsightsSummary;
+  warnings: DataWarning[];
+  purchasesToday: number | null;
+} {
+  const spend = Number.parseFloat(raw.spend ?? '0');
+  const purchases = extractPurchaseCount(raw.actions);
+  const hasPurchaseMetric = Array.isArray(raw.actions)
+    ? raw.actions.some((action) => action.action_type === 'omni_purchase')
+    : false;
+  const warnings: DataWarning[] = [];
+  const dataState: DataState = hasPurchaseMetric ? 'complete' : 'missing';
+
+  if (!hasPurchaseMetric) {
+    warnings.push({
+      code: 'MISSING_OMNI_PURCHASE',
+      message: 'Meta insights payload does not include omni_purchase.',
+      severity: 'warning',
+    });
+  }
+
+  return {
+    insights: {
+      spend: Number.isFinite(spend) ? spend : 0,
+      purchases,
+      purchaseMetric: 'omni_purchase',
+      hasPurchaseMetric,
+      dataState,
+    },
+    warnings,
+    purchasesToday: hasPurchaseMetric ? purchases : null,
+  };
+}
+
+function createThreeDayEvidence(raw: {
+  actions?: MetaActionRecord[];
+}): {
+  purchases3d: number | null;
+  hasPurchaseMetric3d: boolean;
+} {
+  const purchases = extractPurchaseCount(raw.actions);
+  const hasPurchaseMetric3d = Array.isArray(raw.actions)
+    ? raw.actions.some((action) => action.action_type === 'omni_purchase')
+    : false;
+
+  return {
+    purchases3d: hasPurchaseMetric3d ? purchases : null,
+    hasPurchaseMetric3d,
+  };
+}
+
+function determineDecision(
+  campaign: MetaCampaignRecord,
+  config: NormalizedRuleConfig,
+  input: DecisionInputInsights
+): {
+  decision: DecisionType;
+  why: string[];
+  blockers: BlockerReason[];
+} {
+  if (!input.summary.hasPurchaseMetric || !input.hasPurchaseMetric3d || input.purchases3d === null) {
+    return {
+      decision: 'UNKNOWN_DATA',
+      why: ['Cannot make trusted decision without omni_purchase today and 3-day evidence.'],
+      blockers: [
+        {
+          code: 'MISSING_OMNI_PURCHASE',
+          message: 'Missing omni_purchase blocks trusted automation decisions.',
+          blocking: true,
+        },
+      ],
+    };
+  }
+
+  const liveBlockers = buildArmingBlockers(config);
+
+  if (config.excludeCampaignIds.includes(campaign.id)) {
+    return {
+      decision: 'SKIPPED_CAP',
+      why: ['Campaign is excluded from automation.'],
+      blockers: [
+        {
+          code: 'CAMPAIGN_EXCLUDED',
+          message: 'Campaign is in exclusion list.',
+          blocking: true,
+        },
+      ],
+    };
+  }
+
+  if (!config.dryRun && !config.allowlistCampaignIds.includes(campaign.id)) {
+    return {
+      decision: 'BLOCKED_NOT_ARMED',
+      why: ['Campaign is not allowlisted for live automation.'],
+      blockers: [
+        {
+          code: 'CAMPAIGN_NOT_ALLOWED',
+          message: 'Campaign is not present in allowlist.',
+          blocking: true,
+        },
+      ],
+    };
+  }
+
+  if (
+    campaign.status === 'ACTIVE' &&
+    input.summary.spend > config.pauseThreshold &&
+    input.summary.purchases === 0 &&
+    input.purchases3d === 0
+  ) {
+    if (config.dryRun) {
+      return {
+        decision: 'WOULD_PAUSE',
+        why: [
+          `Spend ${input.summary.spend} is above pause threshold ${config.pauseThreshold} with 0 omni_purchase today and 0 omni_purchase over 3 days.`,
+        ],
+        blockers: liveBlockers,
+      };
+    }
+
+    if (liveBlockers.length > 0) {
+      return {
+        decision: 'BLOCKED_NOT_ARMED',
+        why: ['Live pause is blocked until arming requirements pass.'],
+        blockers: liveBlockers,
+      };
+    }
+
+    return {
+      decision: 'PAUSE',
+      why: [
+        `Spend ${input.summary.spend} is above pause threshold ${config.pauseThreshold} with 0 omni_purchase today and 0 omni_purchase over 3 days.`,
+      ],
+      blockers: [],
+    };
+  }
+
+  if (
+    campaign.status === 'ACTIVE' &&
+    config.pauseThreshold2 !== null &&
+    input.summary.spend > config.pauseThreshold2 &&
+    input.summary.purchases < 2 &&
+    input.purchases3d < 2
+  ) {
+    if (config.dryRun) {
+      return {
+        decision: 'WOULD_PAUSE',
+        why: [
+          `Spend ${input.summary.spend} is above pause threshold 2 ${config.pauseThreshold2} with fewer than 2 omni_purchase today and over 3 days.`,
+        ],
+        blockers: liveBlockers,
+      };
+    }
+
+    if (liveBlockers.length > 0) {
+      return {
+        decision: 'BLOCKED_NOT_ARMED',
+        why: ['Live pause is blocked until arming requirements pass.'],
+        blockers: liveBlockers,
+      };
+    }
+
+    return {
+      decision: 'PAUSE',
+      why: [
+        `Spend ${input.summary.spend} is above pause threshold 2 ${config.pauseThreshold2} with fewer than 2 omni_purchase today and over 3 days.`,
+      ],
+      blockers: [],
+    };
+  }
+
+  if (
+    campaign.status === 'PAUSED' &&
+    input.summary.spend < config.resumeThreshold &&
+    input.summary.purchases > 0
+  ) {
+    if (config.dryRun) {
+      return {
+        decision: 'WOULD_RESUME',
+        why: [
+          `Spend ${input.summary.spend} is below resume threshold ${config.resumeThreshold} with ${input.summary.purchases} omni_purchase.`,
+        ],
+        blockers: liveBlockers,
+      };
+    }
+
+    if (liveBlockers.length > 0) {
+      return {
+        decision: 'BLOCKED_NOT_ARMED',
+        why: ['Live resume is blocked until arming requirements pass.'],
+        blockers: liveBlockers,
+      };
+    }
+
+    return {
+      decision: 'RESUME',
+      why: [
+        `Spend ${input.summary.spend} is below resume threshold ${config.resumeThreshold} with ${input.summary.purchases} omni_purchase.`,
+      ],
+      blockers: [],
+    };
+  }
+
+  return {
+    decision: input.warnings.length > 0 ? 'UNKNOWN_DATA' : 'MONITORING',
+    why:
+      input.warnings.length > 0
+        ? ['Monitoring blocked by incomplete decision evidence.']
+        : ['Campaign is being monitored.'],
+    blockers: [],
+  };
+}
+
+function classifyMutationError(error: unknown): ClassifiedError {
+  return {
+    category: 'campaign_mutation',
+    code: 'META_MUTATION_FAILED',
+    message: getErrorMessage(error),
+    retryable: true,
+  };
+}
+
+function createLogEntry(
+  row: CampaignDecisionRow,
+  status: ActionLogEntry['status'],
+  source: ActionLogEntry['source'],
+  runId: string | null,
+  error: ClassifiedError | null = row.error
+): ActionLogEntry {
+  return {
+    id: `${runId ?? 'local'}-${row.id || 'run'}-${row.decision}-${crypto.randomUUID()}`,
+    runId,
+    campaignId: row.id || null,
+    campaignName: row.name || null,
+    decision: row.decision,
+    source,
+    status,
+    occurredAt: getNowIso(),
+    why: [...row.why],
+    blockers: [...row.blockers],
+    warnings: [...row.warnings],
+    error,
+    evidence: row.evidence,
+  };
+}
+
+function createRuleAction(row: CampaignDecisionRow): RuleAction {
+  return {
+    campaignId: row.id,
+    campaignName: row.name,
+    action: row.decision === 'PAUSE' ? 'PAUSE' : 'RESUME',
+    reason: row.why.join(' '),
+    timestamp: getNowIso(),
+    spend: row.evidence.spendToday ?? 0,
+    purchaseCount: row.evidence.purchasesToday ?? 0,
+  };
+}
+
+function toUtcDateString(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function getTrailingDateRange(days: number): { since: string; until: string } {
+  const todayUtc = new Date();
+  const end = new Date(Date.UTC(todayUtc.getUTCFullYear(), todayUtc.getUTCMonth(), todayUtc.getUTCDate()));
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - (days - 1));
+
+  return {
+    since: toUtcDateString(start),
+    until: toUtcDateString(end),
+  };
+}
+
+function buildInsightsMap(rows: MetaAccountInsightsRow[], label: string): Map<string, MetaAccountInsightsRow> {
+  const map = new Map<string, MetaAccountInsightsRow>();
+
+  for (const row of rows) {
+    const campaignId = typeof row.campaign_id === 'string' ? row.campaign_id : '';
+    if (!campaignId) {
+      throw new Error(`${label}_ROW_MISSING_CAMPAIGN_ID`);
+    }
+
+    map.set(campaignId, row);
+  }
+
+  return map;
+}
+
+function createProvenanceBlockedRow(row: CampaignDecisionRow): CampaignDecisionRow {
+  return {
+    ...row,
+    why: [...row.why, 'Live resume blocked because this campaign was not paused by this tool.'],
+    blockers: [
+      ...row.blockers,
+      {
+        code: 'PROVENANCE_REQUIRED',
+        message: 'Live resume requires pausedByTool provenance.',
+        blocking: true,
+      },
+    ],
+  };
+}
+
+interface ProvenanceCheckResult {
+  ok: boolean;
+  allowed: boolean;
+  error: ClassifiedError | null;
+}
+
+function classifyProvenanceLookupError(error: unknown): ClassifiedError {
+  return {
+    category: 'config',
+    code: 'PROVENANCE_LOOKUP_FAILED',
+    message: getErrorMessage(error),
+    retryable: true,
+  };
+}
+
+async function hasToolPauseProvenance(env: Env, campaignId: string): Promise<ProvenanceCheckResult> {
+  if (!env.AUDIT_DB) {
+    return {
+      ok: true,
+      allowed: false,
+      error: null,
+    };
+  }
+
+  try {
+    const state = await env.AUDIT_DB
+      .prepare('SELECT pausedByTool FROM campaign_states WHERE campaignId = ? LIMIT 1')
+      .bind(campaignId)
+      .first<{ pausedByTool: number | null }>();
+
+    return {
+      ok: true,
+      allowed: state?.pausedByTool === 1,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      allowed: false,
+      error: classifyProvenanceLookupError(error),
+    };
+  }
+}
+
+export function createSystemLogEntry(input: {
+  runId: string | null;
+  decision: DecisionType;
+  why: string[];
+  status: ActionLogEntry['status'];
+  source: ActionLogEntry['source'];
+  error?: ClassifiedError | null;
+}): ActionLogEntry {
+  return {
+    id: `${input.runId ?? 'system'}-${input.decision}-${crypto.randomUUID()}`,
+    runId: input.runId,
+    campaignId: null,
+    campaignName: null,
+    decision: input.decision,
+    source: input.source,
+    status: input.status,
+    occurredAt: getNowIso(),
+    why: [...input.why],
+    blockers: [],
+    warnings: [],
+    error: input.error ?? null,
+    evidence: null,
+  };
+}
+
+export async function evaluateCampaigns(env: Env, config: RuleConfig): Promise<CampaignDecisionRow[]> {
+  const normalizedConfig = normalizeRuleConfig(config);
+  const campaigns = await fetchActiveCampaigns(env);
+
+  if (campaigns.length === 0) {
+    return [];
+  }
+
+  const todayInsightsRows = await fetchAccountCampaignInsights(env, {
+    datePreset: 'today',
+  });
+  const trailingThreeDayRows = await fetchAccountCampaignInsights(env, {
+    timeRange: getTrailingDateRange(3),
+  });
+
+  const todayByCampaignId = buildInsightsMap(todayInsightsRows, 'TODAY_INSIGHTS');
+  const threeDayByCampaignId = buildInsightsMap(trailingThreeDayRows, 'THREE_DAY_INSIGHTS');
+
+  return campaigns.map((campaign): CampaignDecisionRow => {
+    const todayRow = todayByCampaignId.get(campaign.id);
+    const threeDayRow = threeDayByCampaignId.get(campaign.id);
+
+    if (!todayRow || !threeDayRow) {
+      throw new Error(`MISSING_REQUIRED_CAMPAIGN_INSIGHT_ROW:${campaign.id}`);
+    }
+
+    const todaySummary = createInsightsSummary(todayRow);
+    const threeDayEvidence = createThreeDayEvidence(threeDayRow);
+    const warnings = [...todaySummary.warnings];
+
+    if (!threeDayEvidence.hasPurchaseMetric3d) {
+      warnings.push({
+        code: 'MISSING_OMNI_PURCHASE',
+        message: 'Meta 3-day insights payload does not include omni_purchase.',
+        severity: 'warning',
+      });
+    }
+
+    const decision = determineDecision(campaign, normalizedConfig, {
+      summary: todaySummary.insights,
+      warnings,
+      purchasesToday: todaySummary.purchasesToday,
+      purchases3d: threeDayEvidence.purchases3d,
+      hasPurchaseMetric3d: threeDayEvidence.hasPurchaseMetric3d,
+    });
+
+    return {
+      id: campaign.id,
+      name: campaign.name,
+      status: campaign.status,
+      decision: decision.decision,
+      why: decision.why,
+      evidence: createEvidence(
+        normalizedConfig,
+        campaign.id,
+        todaySummary.insights,
+        threeDayEvidence.purchases3d
+      ),
+      blockers: decision.blockers,
+      campaignSnapshot: createCampaignSnapshot(
+        campaign,
+        todaySummary.insights,
+        todaySummary.purchasesToday,
+        threeDayEvidence.purchases3d
+      ),
+      warnings,
+      error: null,
+      insights: todaySummary.insights,
+    };
+  });
+}
+
+export async function executeCampaignActions(
+  env: Env,
+  rows: CampaignDecisionRow[],
+  options?: { runId?: string | null }
+): Promise<ExecutionResult> {
+  const runId = options?.runId ?? null;
+  const actions: RuleAction[] = [];
+  const logs: ActionLogEntry[] = [];
+  const campaignStateUpdates: ExecutionResult['campaignStateUpdates'] = [];
+
+  for (const row of rows) {
+    if (row.decision === 'MONITORING') {
+      continue;
+    }
+
+    if (row.decision === 'WOULD_PAUSE' || row.decision === 'WOULD_RESUME') {
+      logs.push(createLogEntry(row, 'skipped', 'dry_run', runId));
+      continue;
+    }
+
+    if (row.decision === 'PAUSE' || row.decision === 'RESUME') {
+      if (row.decision === 'RESUME') {
+        const provenanceCheck = await hasToolPauseProvenance(env, row.id);
+        if (!provenanceCheck.ok) {
+          logs.push(
+            createLogEntry(
+              {
+                ...row,
+                decision: 'ERROR',
+                why: [...row.why, 'Failed to verify pause provenance from audit store.'],
+                blockers: [...row.blockers],
+                error: provenanceCheck.error,
+              },
+              'failed',
+              'system',
+              runId,
+              provenanceCheck.error
+            )
+          );
+          continue;
+        }
+
+        if (!provenanceCheck.allowed) {
+          logs.push(createLogEntry(createProvenanceBlockedRow(row), 'skipped', 'system', runId, null));
+          continue;
+        }
+      }
+
+      try {
+        if (row.decision === 'PAUSE') {
+          await pauseCampaign(env, row.id);
+        } else {
+          await resumeCampaign(env, row.id);
+        }
+
+        const action = createRuleAction(row);
+        actions.push(action);
+        logs.push(createLogEntry(row, 'applied', 'live', runId));
+        campaignStateUpdates.push({
+          campaignId: row.id,
+          lastDecision: row.decision,
+          lastAction: action.action,
+          lastActionAt: action.timestamp,
+          lastRunId: runId,
+          pausedByTool: action.action === 'PAUSE',
+        });
+      } catch (error: unknown) {
+        logs.push(createLogEntry(row, 'failed', 'live', runId, classifyMutationError(error)));
+      }
+
+      continue;
+    }
+
+    if (row.decision === 'ERROR') {
+      logs.push(createLogEntry(row, 'failed', 'system', runId));
+      continue;
+    }
+
+    logs.push(createLogEntry(row, 'skipped', 'system', runId));
+  }
+
+  return {
+    actions,
+    logs,
+    campaignStateUpdates,
+  };
+}
 
 export async function evaluateAndExecuteRules(
   env: Env,
   config: RuleConfig
 ): Promise<RuleAction[]> {
-  const campaigns = await fetchActiveCampaigns(env);
-  const actions: RuleAction[] = [];
-
-  for (const campaign of campaigns) {
-    const insights = await fetchCampaignInsights(env, campaign.id);
-    const spend = parseFloat(insights.spend || '0');
-    const purchases = extractPurchaseCount(insights.actions);
-
-    // PAUSE rule 1
-    if (campaign.status === 'ACTIVE' && spend > config.pauseThreshold && purchases === 0) {
-      await pauseCampaign(env, campaign.id);
-      actions.push({ 
-        campaignId: campaign.id,
-        campaignName: campaign.name,
-        action: 'PAUSE', 
-        reason: `spend=${spend} > ${config.pauseThreshold}, purchases=0`,
-        timestamp: new Date().toISOString(),
-        spend,
-        purchaseCount: purchases
-      });
-    }
-    // PAUSE rule 2
-    else if (campaign.status === 'ACTIVE' && config.pauseThreshold2 && spend > config.pauseThreshold2 && purchases < 2) {
-      await pauseCampaign(env, campaign.id);
-      actions.push({ 
-        campaignId: campaign.id,
-        campaignName: campaign.name,
-        action: 'PAUSE', 
-        reason: `spend=${spend} > ${config.pauseThreshold2}, purchases<2`,
-        timestamp: new Date().toISOString(),
-        spend,
-        purchaseCount: purchases
-      });
-    }
-
-    // RESUME rule
-    if (campaign.status === 'PAUSED' && spend < config.resumeThreshold && purchases > 0) {
-      await resumeCampaign(env, campaign.id);
-      actions.push({ 
-        campaignId: campaign.id,
-        campaignName: campaign.name,
-        action: 'RESUME', 
-        reason: `spend=${spend} < ${config.resumeThreshold}, purchases=${purchases}`,
-        timestamp: new Date().toISOString(),
-        spend,
-        purchaseCount: purchases
-      });
-    }
-  }
-
-  return actions;
+  const rows = await evaluateCampaigns(env, config);
+  const execution = await executeCampaignActions(env, rows);
+  return execution.actions;
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3,6 +3,7 @@ import { evaluateCampaigns, executeCampaignActions, createSystemLogEntry } from 
 import { Router } from './router';
 import { handleOptions, withCors } from './cors';
 import {
+  handleGetAdAccounts,
   handleGetCampaigns,
   handleGetCampaignInsights,
   handleGetConfig,
@@ -12,6 +13,7 @@ import {
 } from './api-handlers';
 
 const DEFAULT_CONFIG: RuleConfig = RULE_CONFIG_DEFAULTS;
+const RULE_CONFIG_KEY = 'RULE_CONFIG';
 const RULE_LOGS_KEY = 'RULE_LOGS';
 const RUN_LOCK_KEY = 'AUTOMATION_RUN_LOCK';
 const RUN_LOCK_TTL_SECONDS = 60 * 25;
@@ -22,6 +24,10 @@ function getRunId(): string {
 
 function getNowIso(): string {
   return new Date().toISOString();
+}
+
+function getAccountScopedKvKey(baseKey: string, env: Env): string {
+  return env.META_ACCOUNT_ID ? `${baseKey}::${env.META_ACCOUNT_ID}` : baseKey;
 }
 
 function getLockPayload(runId: string): string {
@@ -303,9 +309,14 @@ function requireMutationOrigin(request: Request, env: Env): Response | null {
   return jsonAuthError('ORIGIN_FORBIDDEN', 'Origin or referer is not allowed for this mutation.', 403);
 }
 
-async function loadConfig(kv: KVNamespace): Promise<RuleConfig> {
+async function loadConfig(env: Env): Promise<RuleConfig> {
   try {
-    const data = await kv.get('RULE_CONFIG', 'json');
+    const accountScopedData = await env.CONFIG_KV.get(getAccountScopedKvKey(RULE_CONFIG_KEY, env), 'json');
+    if (accountScopedData) {
+      return accountScopedData as RuleConfig;
+    }
+
+    const data = await env.CONFIG_KV.get(RULE_CONFIG_KEY, 'json');
     if (data) {
       return data as RuleConfig;
     }
@@ -316,15 +327,17 @@ async function loadConfig(kv: KVNamespace): Promise<RuleConfig> {
 }
 
 async function logActions(
-  kv: KVNamespace,
+  env: Env,
   actions: Array<RuleAction | ActionLogEntry>
 ): Promise<{ ok: true } | { ok: false; error: ClassifiedError }> {
+  const logsKey = getAccountScopedKvKey(RULE_LOGS_KEY, env);
+
   try {
-    const currentLogsString = await kv.get(RULE_LOGS_KEY, 'text');
+    const currentLogsString = await env.CONFIG_KV.get(logsKey, 'text');
     const logs = currentLogsString ? (JSON.parse(currentLogsString) as Array<RuleAction | ActionLogEntry>) : [];
     const nextLogs = [...actions, ...logs].slice(0, 1000);
 
-    await kv.put(RULE_LOGS_KEY, JSON.stringify(nextLogs));
+    await env.CONFIG_KV.put(logsKey, JSON.stringify(nextLogs));
     return { ok: true };
   } catch (error) {
     const classifiedError: ClassifiedError = {
@@ -340,7 +353,7 @@ async function logActions(
 
 export default {
   async scheduled(_controller: ScheduledController, env: Env, ctx: ExecutionContext) {
-    const config = await loadConfig(env.CONFIG_KV);
+    const config = await loadConfig(env);
     if (!config.enabled) return;
 
     const runId = getRunId();
@@ -355,7 +368,7 @@ export default {
         source: 'system',
       });
 
-      const kvLogResult = await logActions(env.CONFIG_KV, [overlapLog]);
+      const kvLogResult = await logActions(env, [overlapLog]);
       const kvFailureLog =
         kvLogResult.ok
           ? null
@@ -388,7 +401,7 @@ export default {
       const rows = await evaluateCampaigns(env, config);
       const execution = await executeCampaignActions(env, rows, { runId });
       const allLogs = execution.logs.length > 0 ? execution.logs : [];
-      const kvLogResult = allLogs.length > 0 ? await logActions(env.CONFIG_KV, allLogs) : { ok: true as const };
+      const kvLogResult = allLogs.length > 0 ? await logActions(env, allLogs) : { ok: true as const };
       const kvFailureLog =
         kvLogResult.ok
           ? null
@@ -433,7 +446,7 @@ export default {
         error: classifiedError,
       });
 
-      const kvLogResult = await logActions(env.CONFIG_KV, [failureLog]);
+      const kvLogResult = await logActions(env, [failureLog]);
       const auditLogs = kvLogResult.ok
         ? [failureLog]
         : [
@@ -480,6 +493,7 @@ export default {
     }
 
     const router = new Router();
+    router.get('/api/ad-accounts', handleGetAdAccounts);
     router.get('/api/campaigns', handleGetCampaigns);
     router.get('/api/campaigns/:id/insights', handleGetCampaignInsights);
     router.get('/api/config', handleGetConfig);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,5 +1,5 @@
-import { Env, RuleConfig, RuleAction } from './types';
-import { evaluateAndExecuteRules } from './auto-rule-engine';
+import { RULE_CONFIG_DEFAULTS, type ActionLogEntry, type ClassifiedError, type Env, type RuleAction, type RuleConfig, type RunStatus } from './types';
+import { evaluateCampaigns, executeCampaignActions, createSystemLogEntry } from './auto-rule-engine';
 import { Router } from './router';
 import { handleOptions, withCors } from './cors';
 import {
@@ -11,11 +11,297 @@ import {
   handleHealth
 } from './api-handlers';
 
-const DEFAULT_CONFIG: RuleConfig = {
-  pauseThreshold: 170000,
-  resumeThreshold: 150000,
-  enabled: true
-};
+const DEFAULT_CONFIG: RuleConfig = RULE_CONFIG_DEFAULTS;
+const RULE_LOGS_KEY = 'RULE_LOGS';
+const RUN_LOCK_KEY = 'AUTOMATION_RUN_LOCK';
+const RUN_LOCK_TTL_SECONDS = 60 * 25;
+
+function getRunId(): string {
+  return crypto.randomUUID();
+}
+
+function getNowIso(): string {
+  return new Date().toISOString();
+}
+
+function getLockPayload(runId: string): string {
+  return JSON.stringify({ runId, acquiredAt: getNowIso() });
+}
+
+async function tryAcquireRunLock(kv: KVNamespace, runId: string): Promise<boolean> {
+  const existingLock = await kv.get(RUN_LOCK_KEY, 'text');
+  if (existingLock) {
+    return false;
+  }
+
+  await kv.put(RUN_LOCK_KEY, getLockPayload(runId), {
+    expirationTtl: RUN_LOCK_TTL_SECONDS,
+  });
+
+  const confirmedLock = await kv.get(RUN_LOCK_KEY, 'text');
+  if (!confirmedLock) {
+    return false;
+  }
+
+  try {
+    const parsed = JSON.parse(confirmedLock) as { runId?: string };
+    return parsed.runId === runId;
+  } catch {
+    return false;
+  }
+}
+
+async function releaseRunLock(kv: KVNamespace): Promise<void> {
+  await kv.delete(RUN_LOCK_KEY);
+}
+
+async function persistAuditRun(
+  db: D1Database | undefined,
+  input: {
+    runId: string;
+    status: RunStatus;
+    summary?: Record<string, unknown> | null;
+    error?: ClassifiedError | null;
+  }
+): Promise<void> {
+  if (!db) {
+    return;
+  }
+
+  const now = getNowIso();
+  await db
+    .prepare(
+      'INSERT INTO automation_runs (id, status, startedAt, completedAt, failedAt, summaryJson, errorJson) VALUES (?, ?, ?, ?, ?, ?, ?)'
+    )
+    .bind(
+      input.runId,
+      input.status,
+      now,
+      input.status === 'completed' || input.status === 'skipped_overlap' || input.status === 'blocked_live_gate' ? now : null,
+      input.status === 'failed' ? now : null,
+      JSON.stringify(input.summary ?? null),
+      JSON.stringify(input.error ?? null)
+    )
+    .run();
+}
+
+async function persistCampaignStates(
+  db: D1Database | undefined,
+  updates: Array<{
+    campaignId: string;
+    lastDecision: string;
+    lastAction: 'PAUSE' | 'RESUME' | null;
+    lastActionAt: string | null;
+    lastRunId: string | null;
+    pausedByTool: boolean;
+  }>
+): Promise<void> {
+  if (!db || updates.length === 0) {
+    return;
+  }
+
+  for (const update of updates) {
+    await db
+      .prepare(
+        'INSERT INTO campaign_states (campaignId, lastDecision, lastAction, lastActionAt, lastRunId, pausedByTool) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(campaignId) DO UPDATE SET lastDecision=excluded.lastDecision, lastAction=excluded.lastAction, lastActionAt=excluded.lastActionAt, lastRunId=excluded.lastRunId, pausedByTool=excluded.pausedByTool'
+      )
+      .bind(
+        update.campaignId,
+        update.lastDecision,
+        update.lastAction,
+        update.lastActionAt,
+        update.lastRunId,
+        update.pausedByTool ? 1 : 0
+      )
+      .run();
+  }
+}
+
+async function persistAuditLogs(db: D1Database | undefined, logs: ActionLogEntry[]): Promise<void> {
+  if (!db || logs.length === 0) {
+    return;
+  }
+
+  for (const log of logs) {
+    await db
+      .prepare(
+        'INSERT INTO action_logs (id, runId, campaignId, decision, source, status, occurredAt, payloadJson) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+      )
+      .bind(
+        log.id,
+        log.runId ?? 'unknown-run',
+        log.campaignId,
+        log.decision,
+        log.source,
+        log.status,
+        log.occurredAt,
+        JSON.stringify(log)
+      )
+      .run();
+  }
+}
+
+export async function persistConfigVersion(
+  db: D1Database | undefined,
+  input: {
+    version: number;
+    configJson: string;
+    createdAt: string;
+    createdBy: string | null;
+  }
+): Promise<void> {
+  if (!db) {
+    return;
+  }
+
+  await db
+    .prepare(
+      'INSERT INTO config_versions (version, configJson, createdAt, createdBy) VALUES (?, ?, ?, ?)'
+    )
+    .bind(input.version, input.configJson, input.createdAt, input.createdBy)
+    .run();
+}
+
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return 'Unexpected error';
+}
+
+function jsonAuthError(code: string, message: string, status: number): Response {
+  return new Response(
+    JSON.stringify({
+      success: false,
+      data: null,
+      error: {
+        category: 'auth',
+        code,
+        message,
+        retryable: false,
+      },
+      message,
+      meta: {
+        generatedAt: new Date().toISOString(),
+      },
+    }),
+    {
+      status,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+}
+
+function isLocalRequest(request: Request): boolean {
+  const url = new URL(request.url);
+  const origin = request.headers.get('Origin');
+  const referer = request.headers.get('Referer');
+
+  return (
+    url.hostname === 'localhost' ||
+    url.hostname === '127.0.0.1' ||
+    origin?.startsWith('http://localhost:') === true ||
+    origin?.startsWith('http://127.0.0.1:') === true ||
+    referer?.startsWith('http://localhost:') === true ||
+    referer?.startsWith('http://127.0.0.1:') === true
+  );
+}
+
+function isLocalDevBypassEnabled(env: Env): boolean {
+  return env.ALLOW_LOCAL_DEV === 'true';
+}
+
+function hasAccessIdentity(request: Request, env: Env): boolean {
+  if (isLocalRequest(request) && isLocalDevBypassEnabled(env)) {
+    return true;
+  }
+
+  if (env.API_AUTH_TOKEN) {
+    const authHeader = request.headers.get('Authorization');
+    if (authHeader === `Bearer ${env.API_AUTH_TOKEN}`) {
+      return true;
+    }
+  }
+
+  const accessJwt = request.headers.get('CF-Access-Jwt-Assertion');
+  return typeof accessJwt === 'string' && accessJwt.length > 0;
+}
+
+function requireApiAuth(request: Request, env: Env): Response | null {
+  const path = new URL(request.url).pathname;
+  if (!path.startsWith('/api/')) {
+    return null;
+  }
+
+  if (request.method === 'OPTIONS') {
+    return null;
+  }
+
+  if (hasAccessIdentity(request, env)) {
+    return null;
+  }
+
+  return jsonAuthError('ACCESS_UNAUTHORIZED', 'Authentication required for API access.', 401);
+}
+
+function getAllowedOrigin(env: Env): string | null {
+  if (!env.FRONTEND_URL) {
+    return null;
+  }
+
+  try {
+    return new URL(env.FRONTEND_URL).origin;
+  } catch {
+    return null;
+  }
+}
+
+function hasAllowedOrigin(request: Request, env: Env): boolean {
+  if (isLocalRequest(request) && isLocalDevBypassEnabled(env)) {
+    return true;
+  }
+
+  const allowedOrigin = getAllowedOrigin(env);
+  const origin = request.headers.get('Origin');
+  const referer = request.headers.get('Referer');
+
+  if (allowedOrigin && origin === allowedOrigin) {
+    return true;
+  }
+
+  if (allowedOrigin && typeof referer === 'string') {
+    try {
+      return new URL(referer).origin === allowedOrigin;
+    } catch {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+function requireMutationOrigin(request: Request, env: Env): Response | null {
+  const path = new URL(request.url).pathname;
+  const isMutation = request.method !== 'GET' && request.method !== 'OPTIONS';
+
+  if (!isMutation) {
+    return null;
+  }
+
+  if (path !== '/api/config') {
+    return null;
+  }
+
+  if (hasAllowedOrigin(request, env)) {
+    return null;
+  }
+
+  return jsonAuthError('ORIGIN_FORBIDDEN', 'Origin or referer is not allowed for this mutation.', 403);
+}
 
 async function loadConfig(kv: KVNamespace): Promise<RuleConfig> {
   try {
@@ -29,40 +315,169 @@ async function loadConfig(kv: KVNamespace): Promise<RuleConfig> {
   return DEFAULT_CONFIG;
 }
 
-async function logActions(kv: KVNamespace, actions: RuleAction[]) {
+async function logActions(
+  kv: KVNamespace,
+  actions: Array<RuleAction | ActionLogEntry>
+): Promise<{ ok: true } | { ok: false; error: ClassifiedError }> {
   try {
-    const currentLogsString = await kv.get('RULE_LOGS', 'text');
-    let logs: RuleAction[] = [];
-    if (currentLogsString) {
-      logs = JSON.parse(currentLogsString);
-    }
-    
-    // Prepend new actions and keep last 1000 logs
-    logs = [...actions, ...logs].slice(0, 1000);
-    
-    await kv.put('RULE_LOGS', JSON.stringify(logs));
+    const currentLogsString = await kv.get(RULE_LOGS_KEY, 'text');
+    const logs = currentLogsString ? (JSON.parse(currentLogsString) as Array<RuleAction | ActionLogEntry>) : [];
+    const nextLogs = [...actions, ...logs].slice(0, 1000);
+
+    await kv.put(RULE_LOGS_KEY, JSON.stringify(nextLogs));
+    return { ok: true };
   } catch (error) {
+    const classifiedError: ClassifiedError = {
+      category: 'config',
+      code: 'KV_LOG_PERSIST_FAILED',
+      message: getErrorMessage(error),
+      retryable: true,
+    };
     console.error('Failed to save logs to KV', error);
+    return { ok: false, error: classifiedError };
   }
 }
 
 export default {
-  async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext) {
+  async scheduled(_controller: ScheduledController, env: Env, ctx: ExecutionContext) {
     const config = await loadConfig(env.CONFIG_KV);
     if (!config.enabled) return;
-    
+
+    const runId = getRunId();
+    const lockAcquired = await tryAcquireRunLock(env.CONFIG_KV, runId);
+
+    if (!lockAcquired) {
+      const overlapLog = createSystemLogEntry({
+        runId,
+        decision: 'SKIPPED_LOCK',
+        why: ['Skipped overlapping run because automation lock is active.'],
+        status: 'skipped',
+        source: 'system',
+      });
+
+      const kvLogResult = await logActions(env.CONFIG_KV, [overlapLog]);
+      const kvFailureLog =
+        kvLogResult.ok
+          ? null
+          : createSystemLogEntry({
+              runId,
+              decision: 'ERROR',
+              why: ['Failed to persist overlap log to KV.'],
+              status: 'failed',
+              source: 'system',
+              error: kvLogResult.error,
+            });
+      const auditLogs = kvFailureLog ? [overlapLog, kvFailureLog] : [overlapLog];
+
+      await Promise.all([
+        persistAuditRun(env.AUDIT_DB, {
+          runId,
+          status: 'skipped_overlap',
+          summary: {
+            reason: 'lock_active',
+            kvLogWriteStatus: kvLogResult.ok ? 'ok' : 'failed',
+            kvLogError: kvLogResult.ok ? null : kvLogResult.error.code,
+          },
+        }),
+        persistAuditLogs(env.AUDIT_DB, auditLogs),
+      ]);
+      return;
+    }
+
     try {
-      const actions = await evaluateAndExecuteRules(env, config);
-      if (actions.length > 0) {
-        ctx.waitUntil(logActions(env.CONFIG_KV, actions));
-      }
+      const rows = await evaluateCampaigns(env, config);
+      const execution = await executeCampaignActions(env, rows, { runId });
+      const allLogs = execution.logs.length > 0 ? execution.logs : [];
+      const kvLogResult = allLogs.length > 0 ? await logActions(env.CONFIG_KV, allLogs) : { ok: true as const };
+      const kvFailureLog =
+        kvLogResult.ok
+          ? null
+          : createSystemLogEntry({
+              runId,
+              decision: 'ERROR',
+              why: ['Failed to persist automation logs to KV.'],
+              status: 'failed',
+              source: 'system',
+              error: kvLogResult.error,
+            });
+      const auditLogs = kvFailureLog ? [...allLogs, kvFailureLog] : allLogs;
+
+      await Promise.all([
+        persistAuditRun(env.AUDIT_DB, {
+          runId,
+          status: 'completed',
+          summary: {
+            evaluatedCampaigns: rows.length,
+            appliedActions: execution.actions.length,
+            logCount: allLogs.length,
+            kvLogWriteStatus: kvLogResult.ok ? 'ok' : 'failed',
+            kvLogError: kvLogResult.ok ? null : kvLogResult.error.code,
+          },
+        }),
+        persistAuditLogs(env.AUDIT_DB, auditLogs),
+        persistCampaignStates(env.AUDIT_DB, execution.campaignStateUpdates),
+      ]);
     } catch (error) {
+      const classifiedError: ClassifiedError = {
+        category: 'global_insights',
+        code: 'AUTOMATION_RUN_FAILED',
+        message: getErrorMessage(error),
+        retryable: true,
+      };
+      const failureLog = createSystemLogEntry({
+        runId,
+        decision: 'ERROR',
+        why: ['Automation run failed before completion.'],
+        status: 'failed',
+        source: 'system',
+        error: classifiedError,
+      });
+
+      const kvLogResult = await logActions(env.CONFIG_KV, [failureLog]);
+      const auditLogs = kvLogResult.ok
+        ? [failureLog]
+        : [
+            failureLog,
+            createSystemLogEntry({
+              runId,
+              decision: 'ERROR',
+              why: ['Failed to persist failure log to KV.'],
+              status: 'failed',
+              source: 'system',
+              error: kvLogResult.error,
+            }),
+          ];
+
+      await Promise.all([
+        persistAuditRun(env.AUDIT_DB, {
+          runId,
+          status: 'failed',
+          error: classifiedError,
+          summary: {
+            kvLogWriteStatus: kvLogResult.ok ? 'ok' : 'failed',
+            kvLogError: kvLogResult.ok ? null : kvLogResult.error.code,
+          },
+        }),
+        persistAuditLogs(env.AUDIT_DB, auditLogs),
+      ]);
       console.error('Error executing rules:', error);
+    } finally {
+      ctx.waitUntil(releaseRunLock(env.CONFIG_KV));
     }
   },
 
-  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+  async fetch(request: Request, env: Env, _ctx: ExecutionContext) {
     if (request.method === 'OPTIONS') return handleOptions(request, env);
+
+    const authError = requireApiAuth(request, env);
+    if (authError) {
+      return withCors(authError, env, request);
+    }
+
+    const originError = requireMutationOrigin(request, env);
+    if (originError) {
+      return withCors(originError, env, request);
+    }
 
     const router = new Router();
     router.get('/api/campaigns', handleGetCampaigns);
@@ -72,7 +487,37 @@ export default {
     router.get('/api/logs', handleGetLogs);
     router.get('/api/health', handleHealth);
 
-    const response = await router.handle(request, env);
-    return withCors(response, env, request);
+    try {
+      const response = await router.handle(request, env);
+      return withCors(response, env, request);
+    } catch (error) {
+      return withCors(
+        new Response(
+          JSON.stringify({
+            success: false,
+            data: null,
+            error: {
+              category: 'auth',
+              code: 'UNEXPECTED_FETCH_ERROR',
+              message: getErrorMessage(error),
+              retryable: true,
+            },
+            message: getErrorMessage(error),
+            meta: {
+              generatedAt: new Date().toISOString(),
+            },
+          }),
+          {
+            status: 500,
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          }
+        ),
+        env,
+        request
+      );
+    }
   }
 } satisfies ExportedHandler<Env>;
+

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -520,4 +520,3 @@ export default {
     }
   }
 } satisfies ExportedHandler<Env>;
-

--- a/worker/src/meta-api-client.ts
+++ b/worker/src/meta-api-client.ts
@@ -1,84 +1,179 @@
-import { Env, CampaignInsight } from './types';
+import { Env } from './types';
 
-export async function fetchActiveCampaigns(env: Env) {
-  const url = `https://graph.facebook.com/v21.0/act_${env.META_ACCOUNT_ID}/campaigns?fields=id,name,status&filtering=[{"field":"effective_status","operator":"IN","value":["ACTIVE","PAUSED"]}]&access_token=${env.META_ACCESS_TOKEN}`;
-  
-  const response = await fetch(url);
-  const data: any = await response.json();
-  
-  if (data.error) {
-    throw new Error(`Meta API Error: ${data.error.message}`);
-  }
-  
-  return data.data || [];
+interface MetaApiError {
+  message: string;
 }
 
-export async function fetchCampaignInsights(env: Env, campaignId: string) {
-  const url = `https://graph.facebook.com/v21.0/${campaignId}/insights?date_preset=today&fields=spend,actions&access_token=${env.META_ACCESS_TOKEN}`;
-  
-  const response = await fetch(url);
-  const data: any = await response.json();
-  
+interface MetaPaging {
+  next?: string;
+}
+
+interface MetaApiResponse<T> {
+  data?: T;
+  error?: MetaApiError;
+  paging?: MetaPaging;
+}
+
+export interface MetaCampaignRecord {
+  id: string;
+  name: string;
+  status: 'ACTIVE' | 'PAUSED';
+}
+
+export interface MetaActionRecord {
+  action_type: string;
+  value: string;
+}
+
+export interface MetaInsightsResponseRow {
+  spend?: string;
+  actions?: MetaActionRecord[];
+}
+
+export interface MetaAccountInsightsRow {
+  campaign_id?: string;
+  campaign_name?: string;
+  spend?: string;
+  actions?: MetaActionRecord[];
+  date_start?: string;
+  date_stop?: string;
+}
+
+interface InsightsTimeRange {
+  since: string;
+  until: string;
+}
+
+function metaHeaders(env: Env, includeJsonContentType = false): HeadersInit {
+  return {
+    Authorization: `Bearer ${env.META_ACCESS_TOKEN}`,
+    ...(includeJsonContentType ? { 'Content-Type': 'application/json' } : {}),
+  };
+}
+
+async function parseMetaEnvelope<T>(response: Response, errorPrefix: string): Promise<MetaApiResponse<T>> {
+  const data = (await response.json()) as MetaApiResponse<T>;
+
   if (data.error) {
-    throw new Error(`Meta API Error: ${data.error.message}`);
+    throw new Error(`${errorPrefix}: ${data.error.message}`);
   }
-  
-  if (!data.data || data.data.length === 0) {
+
+  return data;
+}
+
+function buildAccountInsightsUrl(
+  env: Env,
+  options: {
+    datePreset?: 'today';
+    timeRange?: InsightsTimeRange;
+  }
+): string {
+  const params = new URLSearchParams();
+  params.set('fields', 'campaign_id,campaign_name,spend,actions');
+  params.set('level', 'campaign');
+  params.set('limit', '200');
+
+  if (options.timeRange) {
+    params.set('time_range', JSON.stringify(options.timeRange));
+    params.set('time_increment', 'all_days');
+  } else {
+    params.set('date_preset', options.datePreset ?? 'today');
+  }
+
+  return `https://graph.facebook.com/v21.0/act_${env.META_ACCOUNT_ID}/insights?${params.toString()}`;
+}
+
+export async function fetchActiveCampaigns(env: Env): Promise<MetaCampaignRecord[]> {
+  let nextUrl: string | null = `https://graph.facebook.com/v21.0/act_${env.META_ACCOUNT_ID}/campaigns?fields=id,name,status&filtering=[{"field":"effective_status","operator":"IN","value":["ACTIVE","PAUSED"]}]`;
+  const campaigns: MetaCampaignRecord[] = [];
+
+  while (nextUrl) {
+    const response = await fetch(nextUrl, {
+      headers: metaHeaders(env),
+    });
+
+    const envelope = await parseMetaEnvelope<MetaCampaignRecord[]>(response, 'Meta API Error');
+    campaigns.push(...(envelope.data || []));
+    nextUrl = envelope.paging?.next ?? null;
+  }
+
+  return campaigns;
+}
+
+export async function fetchAccountCampaignInsights(
+  env: Env,
+  options: {
+    datePreset?: 'today';
+    timeRange?: InsightsTimeRange;
+  }
+): Promise<MetaAccountInsightsRow[]> {
+  let nextUrl: string | null = buildAccountInsightsUrl(env, options);
+  const rows: MetaAccountInsightsRow[] = [];
+
+  while (nextUrl) {
+    const response = await fetch(nextUrl, {
+      headers: metaHeaders(env),
+    });
+
+    const envelope = await parseMetaEnvelope<MetaAccountInsightsRow[]>(response, 'Meta API Insights Error');
+    rows.push(...(envelope.data || []));
+    nextUrl = envelope.paging?.next ?? null;
+  }
+
+  return rows;
+}
+
+export async function fetchCampaignInsights(env: Env, campaignId: string): Promise<MetaInsightsResponseRow> {
+  const url = `https://graph.facebook.com/v21.0/${campaignId}/insights?date_preset=today&fields=spend,actions`;
+
+  const response = await fetch(url, {
+    headers: metaHeaders(env),
+  });
+
+  const envelope = await parseMetaEnvelope<MetaInsightsResponseRow[]>(response, 'Meta API Error');
+  const data = envelope.data;
+
+  if (!data || data.length === 0) {
     return { spend: '0', actions: [] };
   }
-  
-  return data.data[0];
+
+  return data[0];
 }
 
-export async function pauseCampaign(env: Env, campaignId: string) {
+export async function pauseCampaign(env: Env, campaignId: string): Promise<unknown> {
   const url = `https://graph.facebook.com/v21.0/${campaignId}`;
-  
+
   const response = await fetch(url, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
+    headers: metaHeaders(env, true),
     body: JSON.stringify({
       status: 'PAUSED',
-      access_token: env.META_ACCESS_TOKEN
-    })
+    }),
   });
-  
-  const data: any = await response.json();
-  if (data.error) {
-    throw new Error(`Meta API Error pausing campaign: ${data.error.message}`);
-  }
-  
-  return data;
+
+  const envelope = await parseMetaEnvelope<unknown>(response, 'Meta API Error pausing campaign');
+  return envelope.data;
 }
 
-export async function resumeCampaign(env: Env, campaignId: string) {
+export async function resumeCampaign(env: Env, campaignId: string): Promise<unknown> {
   const url = `https://graph.facebook.com/v21.0/${campaignId}`;
-  
+
   const response = await fetch(url, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
+    headers: metaHeaders(env, true),
     body: JSON.stringify({
       status: 'ACTIVE',
-      access_token: env.META_ACCESS_TOKEN
-    })
+    }),
   });
-  
-  const data: any = await response.json();
-  if (data.error) {
-    throw new Error(`Meta API Error resuming campaign: ${data.error.message}`);
-  }
-  
-  return data;
+
+  const envelope = await parseMetaEnvelope<unknown>(response, 'Meta API Error resuming campaign');
+  return envelope.data;
 }
 
-export function extractPurchaseCount(actions: any[]): number {
+export function extractPurchaseCount(actions: MetaActionRecord[] | undefined): number {
   if (!actions || !Array.isArray(actions)) return 0;
-  
-  const purchaseAction = actions.find((a: any) => a.action_type === 'omni_purchase') || 
-                         actions.find((a: any) => a.action_type === 'purchase');
-                         
+
+  const purchaseAction = actions.find((a) => a.action_type === 'omni_purchase');
+
   return purchaseAction ? parseInt(purchaseAction.value, 10) : 0;
 }

--- a/worker/src/meta-api-client.ts
+++ b/worker/src/meta-api-client.ts
@@ -1,4 +1,4 @@
-import { Env } from './types';
+import { type AdAccount, Env } from './types';
 
 interface MetaApiError {
   message: string;
@@ -51,6 +51,11 @@ function metaHeaders(env: Env, includeJsonContentType = false): HeadersInit {
   };
 }
 
+function buildAdAccountPath(accountId: string): string {
+  const normalizedAccountId = accountId.startsWith('act_') ? accountId.slice(4) : accountId;
+  return `act_${normalizedAccountId}`;
+}
+
 async function parseMetaEnvelope<T>(response: Response, errorPrefix: string): Promise<MetaApiResponse<T>> {
   const data = (await response.json()) as MetaApiResponse<T>;
 
@@ -62,7 +67,7 @@ async function parseMetaEnvelope<T>(response: Response, errorPrefix: string): Pr
 }
 
 function buildAccountInsightsUrl(
-  env: Env,
+  accountId: string,
   options: {
     datePreset?: 'today';
     timeRange?: InsightsTimeRange;
@@ -80,11 +85,28 @@ function buildAccountInsightsUrl(
     params.set('date_preset', options.datePreset ?? 'today');
   }
 
-  return `https://graph.facebook.com/v21.0/act_${env.META_ACCOUNT_ID}/insights?${params.toString()}`;
+  return `https://graph.facebook.com/v21.0/${buildAdAccountPath(accountId)}/insights?${params.toString()}`;
 }
 
-export async function fetchActiveCampaigns(env: Env): Promise<MetaCampaignRecord[]> {
-  let nextUrl: string | null = `https://graph.facebook.com/v21.0/act_${env.META_ACCOUNT_ID}/campaigns?fields=id,name,status&filtering=[{"field":"effective_status","operator":"IN","value":["ACTIVE","PAUSED"]}]`;
+export async function fetchAdAccounts(env: Env): Promise<AdAccount[]> {
+  let nextUrl: string | null = 'https://graph.facebook.com/v21.0/me/adaccounts?fields=id,account_id,name,account_status';
+  const accounts: AdAccount[] = [];
+
+  while (nextUrl) {
+    const response = await fetch(nextUrl, {
+      headers: metaHeaders(env),
+    });
+
+    const envelope = await parseMetaEnvelope<AdAccount[]>(response, 'Meta API Ad Accounts Error');
+    accounts.push(...(envelope.data || []));
+    nextUrl = envelope.paging?.next ?? null;
+  }
+
+  return accounts;
+}
+
+export async function fetchActiveCampaigns(env: Env, accountId = env.META_ACCOUNT_ID): Promise<MetaCampaignRecord[]> {
+  let nextUrl: string | null = `https://graph.facebook.com/v21.0/${buildAdAccountPath(accountId)}/campaigns?fields=id,name,status&filtering=[{"field":"effective_status","operator":"IN","value":["ACTIVE","PAUSED"]}]`;
   const campaigns: MetaCampaignRecord[] = [];
 
   while (nextUrl) {
@@ -103,11 +125,12 @@ export async function fetchActiveCampaigns(env: Env): Promise<MetaCampaignRecord
 export async function fetchAccountCampaignInsights(
   env: Env,
   options: {
+    accountId?: string;
     datePreset?: 'today';
     timeRange?: InsightsTimeRange;
   }
 ): Promise<MetaAccountInsightsRow[]> {
-  let nextUrl: string | null = buildAccountInsightsUrl(env, options);
+  let nextUrl: string | null = buildAccountInsightsUrl(options.accountId ?? env.META_ACCOUNT_ID, options);
   const rows: MetaAccountInsightsRow[] = [];
 
   while (nextUrl) {

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -2,22 +2,199 @@ export interface Env {
   META_ACCESS_TOKEN: string;
   META_ACCOUNT_ID: string;
   CONFIG_KV: KVNamespace;
+  AUDIT_DB?: D1Database;
   FRONTEND_URL?: string;
+  API_AUTH_TOKEN?: string;
+  CLOUDFLARE_ACCESS_AUD?: string;
+  ALLOW_LOCAL_DEV?: string;
+}
+
+export type CampaignStatus = 'ACTIVE' | 'PAUSED';
+export type PurchaseMetric = 'omni_purchase';
+export type DecisionType =
+  | 'WOULD_PAUSE'
+  | 'WOULD_RESUME'
+  | 'PAUSE'
+  | 'RESUME'
+  | 'MONITORING'
+  | 'SKIPPED_COOLDOWN'
+  | 'SKIPPED_CAP'
+  | 'SKIPPED_LOCK'
+  | 'BLOCKED_NOT_ARMED'
+  | 'UNKNOWN_DATA'
+  | 'ERROR';
+export type RunStatus = 'started' | 'completed' | 'failed' | 'skipped_overlap' | 'blocked_live_gate';
+export type ErrorCategory =
+  | 'auth'
+  | 'config'
+  | 'global_insights'
+  | 'campaign_mutation'
+  | 'validation';
+export type HealthStatus = 'ok' | 'degraded' | 'error';
+export type ConfigWriteStatus = 'saved' | 'validation_error' | 'version_conflict' | 'blocked_live_gate';
+export type ActivitySource = 'dry_run' | 'live' | 'system';
+export type DataState = 'complete' | 'partial' | 'missing' | 'error';
+export type WarningSeverity = 'info' | 'warning' | 'error';
+export type ArmingStatus = 'not_armed' | 'eligible' | 'armed' | 'blocked';
+export type BlockerCode =
+  | 'AD_ACCOUNT_CONFIRMATION_REQUIRED'
+  | 'ALLOWLIST_REQUIRED'
+  | 'ACTION_CAPS_REQUIRED'
+  | 'RECENT_DRY_RUN_REVIEW_REQUIRED'
+  | 'EMERGENCY_STOP'
+  | 'COOLDOWN_ACTIVE'
+  | 'RUN_CAP_REACHED'
+  | 'DAY_CAP_REACHED'
+  | 'CAMPAIGN_NOT_ALLOWED'
+  | 'CAMPAIGN_EXCLUDED'
+  | 'LOCK_ACTIVE'
+  | 'PROVENANCE_REQUIRED'
+  | 'GLOBAL_INSIGHTS_UNAVAILABLE'
+  | 'MISSING_OMNI_PURCHASE';
+export type WarningCode = 'MISSING_OMNI_PURCHASE' | 'PARTIAL_INSIGHTS' | 'INSIGHTS_UNAVAILABLE';
+
+export interface ApiValidationErrorDetail {
+  field: string;
+  code: string;
+  message: string;
+}
+
+export interface ClassifiedError {
+  category: ErrorCategory;
+  code: string;
+  message: string;
+  retryable: boolean;
+  details?: ApiValidationErrorDetail[];
+}
+
+export interface BlockerReason {
+  code: BlockerCode;
+  message: string;
+  blocking: boolean;
+}
+
+export interface DataWarning {
+  code: WarningCode;
+  message: string;
+  severity: WarningSeverity;
+}
+
+export interface ArmingState {
+  status: ArmingStatus;
+  adAccountConfirmed: boolean;
+  recentDryRunRunId: string | null;
+  recentDryRunReviewedAt: string | null;
+  reviewedBy: string | null;
+  reliabilityScore: number | null;
+  evidenceWindowDays: number;
 }
 
 export interface RuleConfig {
-  pauseThreshold: number;
-  pauseThreshold2?: number;
-  resumeThreshold: number;
   enabled: boolean;
+  dryRun?: boolean;
+  pauseThreshold: number;
+  pauseThreshold2?: number | null;
+  resumeThreshold: number;
+  cooldownHours?: number;
+  maxActionsPerRun?: number;
+  maxActionsPerDay?: number;
+  allowlistCampaignIds?: string[];
+  excludeCampaignIds?: string[];
+  emergencyStop?: boolean;
+  arming?: Partial<ArmingState>;
 }
+
+export interface NormalizedRuleConfig extends RuleConfig {
+  dryRun: boolean;
+  pauseThreshold2: number | null;
+  cooldownHours: number;
+  maxActionsPerRun: number;
+  maxActionsPerDay: number;
+  allowlistCampaignIds: string[];
+  excludeCampaignIds: string[];
+  emergencyStop: boolean;
+  arming: ArmingState;
+}
+
+export const RULE_CONFIG_DEFAULTS: NormalizedRuleConfig = {
+  enabled: true,
+  dryRun: true,
+  pauseThreshold: 170000,
+  pauseThreshold2: 200000,
+  resumeThreshold: 150000,
+  cooldownHours: 24,
+  maxActionsPerRun: 0,
+  maxActionsPerDay: 0,
+  allowlistCampaignIds: [],
+  excludeCampaignIds: [],
+  emergencyStop: false,
+  arming: {
+    status: 'not_armed',
+    adAccountConfirmed: false,
+    recentDryRunRunId: null,
+    recentDryRunReviewedAt: null,
+    reviewedBy: null,
+    reliabilityScore: null,
+    evidenceWindowDays: 3,
+  },
+};
 
 export interface CampaignInsight {
   campaignId: string;
   campaignName: string;
-  status: 'ACTIVE' | 'PAUSED';
+  status: CampaignStatus;
   spend: number;
   purchaseCount: number;
+  purchaseMetric: PurchaseMetric;
+  hasPurchaseMetric: boolean;
+  dataState: DataState;
+}
+
+export interface CampaignInsightsSummary {
+  spend: number;
+  purchases: number;
+  purchaseMetric: PurchaseMetric;
+  hasPurchaseMetric: boolean;
+  dataState: DataState;
+}
+
+export interface CampaignSnapshot {
+  id: string;
+  name: string;
+  status: CampaignStatus;
+  spendToday: number | null;
+  purchasesToday: number | null;
+  purchases3d: number | null;
+  purchaseMetric: PurchaseMetric;
+  hasPurchaseMetric: boolean;
+  dataState: DataState;
+}
+
+export interface DecisionEvidence {
+  spendToday: number | null;
+  purchasesToday: number | null;
+  purchases3d: number | null;
+  purchaseMetric: PurchaseMetric;
+  dataState: DataState;
+  dryRun: boolean;
+  cooldownHours: number;
+  maxActionsPerRun: number;
+  maxActionsPerDay: number;
+  allowlisted: boolean;
+  excluded: boolean;
+  emergencyStop: boolean;
+  armingStatus: ArmingStatus;
+  reliabilityScore: number | null;
+}
+
+export interface EvaluatorResult {
+  decision: DecisionType;
+  why: string[];
+  evidence: DecisionEvidence;
+  blockers: BlockerReason[];
+  campaignSnapshot: CampaignSnapshot;
+  warnings: DataWarning[];
+  error: ClassifiedError | null;
 }
 
 export interface RuleAction {
@@ -28,4 +205,144 @@ export interface RuleAction {
   timestamp: string;
   spend: number;
   purchaseCount: number;
+}
+
+export interface ActionLogEntry {
+  id: string;
+  runId: string | null;
+  campaignId: string | null;
+  campaignName: string | null;
+  decision: DecisionType;
+  source: ActivitySource;
+  status: 'applied' | 'skipped' | 'failed';
+  occurredAt: string;
+  why: string[];
+  blockers: BlockerReason[];
+  warnings: DataWarning[];
+  error: ClassifiedError | null;
+  evidence: DecisionEvidence | null;
+}
+
+export interface ConfigVersionRow {
+  id: number;
+  version: number;
+  configJson: string;
+  createdAt: string;
+  createdBy: string | null;
+}
+
+export interface AutomationRunRow {
+  id: string;
+  status: RunStatus;
+  startedAt: string;
+  completedAt: string | null;
+  failedAt: string | null;
+  summaryJson: string | null;
+  errorJson: string | null;
+}
+
+export interface CampaignStateRow {
+  campaignId: string;
+  lastDecision: DecisionType | null;
+  lastAction: 'PAUSE' | 'RESUME' | null;
+  lastActionAt: string | null;
+  lastRunId: string | null;
+  pausedByTool: boolean;
+}
+
+export interface ActionLogRow {
+  id: string;
+  runId: string;
+  campaignId: string | null;
+  decision: DecisionType;
+  source: ActivitySource;
+  status: 'applied' | 'skipped' | 'failed';
+  occurredAt: string;
+  payloadJson: string;
+}
+
+export interface RunHealthSummary {
+  currentStatus: RunStatus | null;
+  lastStartedAt: string | null;
+  lastCompletedAt: string | null;
+  lastFailedAt: string | null;
+  nextScheduledAt: string | null;
+  activeLock: boolean;
+  activeRunId: string | null;
+}
+
+export interface CampaignDecisionRow extends EvaluatorResult {
+  id: string;
+  name: string;
+  status: CampaignStatus;
+  insights: CampaignInsightsSummary | null;
+}
+
+export interface ConfigReadModel extends NormalizedRuleConfig {
+  dryRun: boolean;
+  pauseThreshold2: number | null;
+  cooldownHours: number;
+  maxActionsPerRun: number;
+  maxActionsPerDay: number;
+  allowlistCampaignIds: string[];
+  excludeCampaignIds: string[];
+  emergencyStop: boolean;
+  arming: ArmingState;
+  version: number | null;
+  updatedAt: string | null;
+  updatedBy: string | null;
+  liveArmingEligible: boolean;
+  armingBlockers: BlockerReason[];
+}
+
+export interface ConfigWriteSuccessPayload {
+  status: ConfigWriteStatus;
+  config: ConfigReadModel;
+}
+
+export interface ConfigVersionConflictPayload {
+  status: ConfigWriteStatus;
+  currentVersion: number | null;
+  submittedVersion: number | null;
+  latestConfig: ConfigReadModel;
+}
+
+export interface ConfigWriteBlockedPayload {
+  status: ConfigWriteStatus;
+  config: ConfigReadModel;
+  blockers: BlockerReason[];
+}
+
+export interface HealthPayload {
+  status: HealthStatus;
+  message: string;
+  checkedAt: string;
+  metaAccountId: string;
+}
+
+export interface RunStatusPayload {
+  run: RunHealthSummary;
+}
+
+export interface ApiResponseMeta {
+  generatedAt: string;
+  total?: number;
+  version?: number | null;
+  run?: RunHealthSummary | null;
+}
+
+export interface ApiSuccessResponse<T, M = ApiResponseMeta> {
+  success: true;
+  data: T;
+  error: null;
+  message?: string;
+  meta?: M;
+}
+
+export interface ApiErrorResponse<T = null, M = ApiResponseMeta> {
+  success: false;
+  data: T;
+  error: ClassifiedError;
+  message: string;
+  meta?: M;
 }

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -53,6 +53,13 @@ export type BlockerCode =
   | 'MISSING_OMNI_PURCHASE';
 export type WarningCode = 'MISSING_OMNI_PURCHASE' | 'PARTIAL_INSIGHTS' | 'INSIGHTS_UNAVAILABLE';
 
+export interface AdAccount {
+  id: string;
+  account_id: string;
+  name: string;
+  account_status: number;
+}
+
 export interface ApiValidationErrorDetail {
   field: string;
   code: string;

--- a/worker/test/auth-guard.spec.ts
+++ b/worker/test/auth-guard.spec.ts
@@ -146,10 +146,122 @@ describe("auth guard", () => {
     });
   });
 
+  it("requires accountId for account-scoped config reads", async () => {
+    const request = new Request("https://api.example.com/api/config", {
+      headers: {
+        Authorization: "Bearer api-test-token",
+      },
+    });
+    const ctx = createExecutionContext();
+
+    const response = await worker.fetch(request, createEnv(), ctx);
+
+    await waitOnExecutionContext(ctx);
+
+    expect(response.status).toBe(400);
+
+    const body = (await response.json()) as ApiErrorResponse;
+    expect(body.success).toBe(false);
+    expect(body.error.category).toBe("validation");
+    expect(body.error.code).toBe("MISSING_ACCOUNT_ID");
+  });
+
+  it("stores configs independently per accountId", async () => {
+    const kv = new FakeKVNamespace();
+    const payload = {
+      enabled: true,
+      dryRun: true,
+      pauseThreshold: 170000,
+      pauseThreshold2: 200000,
+      resumeThreshold: 150000,
+      cooldownHours: 24,
+      maxActionsPerRun: 0,
+      maxActionsPerDay: 0,
+      allowlistCampaignIds: [],
+      excludeCampaignIds: [],
+      emergencyStop: false,
+      arming: {
+        status: "not_armed",
+        adAccountConfirmed: false,
+        recentDryRunRunId: null,
+        recentDryRunReviewedAt: null,
+        reviewedBy: null,
+        reliabilityScore: null,
+        evidenceWindowDays: 3,
+      },
+      version: null,
+    };
+
+    const ctxA = createExecutionContext();
+    const saveA = await worker.fetch(
+      new Request("https://api.example.com/api/config?accountId=111", {
+        method: "PUT",
+        headers: {
+          Authorization: "Bearer api-test-token",
+          Origin: "https://dashboard.example.com",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ ...payload, pauseThreshold: 111 }),
+      }),
+      createEnv({ CONFIG_KV: kv as unknown as Env["CONFIG_KV"] }),
+      ctxA
+    );
+    await waitOnExecutionContext(ctxA);
+
+    const ctxB = createExecutionContext();
+    const saveB = await worker.fetch(
+      new Request("https://api.example.com/api/config?accountId=222", {
+        method: "PUT",
+        headers: {
+          Authorization: "Bearer api-test-token",
+          Origin: "https://dashboard.example.com",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ ...payload, pauseThreshold: 222 }),
+      }),
+      createEnv({ CONFIG_KV: kv as unknown as Env["CONFIG_KV"] }),
+      ctxB
+    );
+    await waitOnExecutionContext(ctxB);
+
+    expect(saveA.status).toBe(200);
+    expect(saveB.status).toBe(200);
+
+    const ctxReadA = createExecutionContext();
+    const readA = await worker.fetch(
+      new Request("https://api.example.com/api/config?accountId=111", {
+        headers: {
+          Authorization: "Bearer api-test-token",
+        },
+      }),
+      createEnv({ CONFIG_KV: kv as unknown as Env["CONFIG_KV"] }),
+      ctxReadA
+    );
+    await waitOnExecutionContext(ctxReadA);
+
+    const ctxReadB = createExecutionContext();
+    const readB = await worker.fetch(
+      new Request("https://api.example.com/api/config?accountId=222", {
+        headers: {
+          Authorization: "Bearer api-test-token",
+        },
+      }),
+      createEnv({ CONFIG_KV: kv as unknown as Env["CONFIG_KV"] }),
+      ctxReadB
+    );
+    await waitOnExecutionContext(ctxReadB);
+
+    const bodyA = (await readA.json()) as { data: { pauseThreshold: number } };
+    const bodyB = (await readB.json()) as { data: { pauseThreshold: number } };
+
+    expect(bodyA.data.pauseThreshold).toBe(111);
+    expect(bodyB.data.pauseThreshold).toBe(222);
+  });
+
   it("persists config_versions row on successful config save", async () => {
     const kv = new FakeKVNamespace();
     const db = env.AUDIT_DB!;
-    const request = new Request("https://api.example.com/api/config", {
+    const request = new Request("https://api.example.com/api/config?accountId=account-for-audit", {
       method: "PUT",
       headers: {
         Authorization: "Bearer api-test-token",

--- a/worker/test/auth-guard.spec.ts
+++ b/worker/test/auth-guard.spec.ts
@@ -1,0 +1,198 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import worker from "../src/index";
+import type { ApiErrorResponse, Env } from "../src/types";
+
+declare module "cloudflare:test" {
+  interface ProvidedEnv extends Env {}
+}
+
+class FakeKVNamespace {
+  private readonly store = new Map<string, string>();
+
+  async get(key: string, type?: "text" | "json"): Promise<string | unknown | null> {
+    const value = this.store.get(key);
+    if (typeof value !== "string") {
+      return null;
+    }
+
+    if (type === "json") {
+      return JSON.parse(value) as unknown;
+    }
+
+    return value;
+  }
+
+  async put(key: string, value: string): Promise<void> {
+    this.store.set(key, value);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+}
+
+function createEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    META_ACCESS_TOKEN: "test-token",
+    META_ACCOUNT_ID: "test-account",
+    CONFIG_KV: (overrides.CONFIG_KV ?? new FakeKVNamespace()) as unknown as Env["CONFIG_KV"],
+    AUDIT_DB: overrides.AUDIT_DB,
+    FRONTEND_URL: "https://dashboard.example.com",
+    API_AUTH_TOKEN: "api-test-token",
+    ALLOW_LOCAL_DEV: "false",
+  };
+}
+
+describe("auth guard", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("rejects unauthenticated API requests", async () => {
+    const request = new Request("https://api.example.com/api/config");
+    const ctx = createExecutionContext();
+
+    const response = await worker.fetch(request, createEnv(), ctx);
+
+    await waitOnExecutionContext(ctx);
+
+    expect(response.status).toBe(401);
+
+    const body = (await response.json()) as ApiErrorResponse;
+    expect(body.success).toBe(false);
+    expect(body.error.category).toBe("auth");
+    expect(body.error.code).toBe("ACCESS_UNAUTHORIZED");
+  });
+
+  it("rejects config writes from disallowed origin even when authenticated", async () => {
+    const request = new Request("https://api.example.com/api/config", {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer api-test-token",
+        Origin: "https://evil.example.com",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        enabled: true,
+        dryRun: true,
+        pauseThreshold: 170000,
+        pauseThreshold2: 200000,
+        resumeThreshold: 150000,
+        cooldownHours: 24,
+        maxActionsPerRun: 0,
+        maxActionsPerDay: 0,
+        allowlistCampaignIds: [],
+        excludeCampaignIds: [],
+        emergencyStop: false,
+        arming: {
+          status: "not_armed",
+          adAccountConfirmed: false,
+          recentDryRunRunId: null,
+          recentDryRunReviewedAt: null,
+          reviewedBy: null,
+          reliabilityScore: null,
+          evidenceWindowDays: 3,
+        },
+        version: null,
+      }),
+    });
+    const ctx = createExecutionContext();
+
+    const response = await worker.fetch(request, createEnv(), ctx);
+
+    await waitOnExecutionContext(ctx);
+
+    expect(response.status).toBe(403);
+
+    const body = (await response.json()) as ApiErrorResponse;
+    expect(body.success).toBe(false);
+    expect(body.error.category).toBe("auth");
+    expect(body.error.code).toBe("ORIGIN_FORBIDDEN");
+  });
+
+  it("uses Authorization Bearer header for health check without access_token in URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "me" }), {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new Request("https://api.example.com/api/health", {
+      headers: {
+        Authorization: "Bearer api-test-token",
+      },
+    });
+    const ctx = createExecutionContext();
+
+    const response = await worker.fetch(request, createEnv(), ctx);
+
+    await waitOnExecutionContext(ctx);
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit | undefined];
+    expect(url).toBe("https://graph.facebook.com/v21.0/me");
+    expect(url).not.toContain("access_token=");
+    expect(init?.headers).toMatchObject({
+      Authorization: "Bearer test-token",
+    });
+  });
+
+  it("persists config_versions row on successful config save", async () => {
+    const kv = new FakeKVNamespace();
+    const db = env.AUDIT_DB!;
+    const request = new Request("https://api.example.com/api/config", {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer api-test-token",
+        Origin: "https://dashboard.example.com",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        enabled: true,
+        dryRun: true,
+        pauseThreshold: 170000,
+        pauseThreshold2: 200000,
+        resumeThreshold: 150000,
+        cooldownHours: 24,
+        maxActionsPerRun: 0,
+        maxActionsPerDay: 0,
+        allowlistCampaignIds: [],
+        excludeCampaignIds: [],
+        emergencyStop: false,
+        arming: {
+          status: "not_armed",
+          adAccountConfirmed: false,
+          recentDryRunRunId: null,
+          recentDryRunReviewedAt: null,
+          reviewedBy: null,
+          reliabilityScore: null,
+          evidenceWindowDays: 3,
+        },
+        version: null,
+      }),
+    });
+    const ctx = createExecutionContext();
+
+    const response = await worker.fetch(request, createEnv({ CONFIG_KV: kv as unknown as Env["CONFIG_KV"], AUDIT_DB: db }), ctx);
+
+    await waitOnExecutionContext(ctx);
+
+    expect(response.status).toBe(200);
+
+    const versions = await db.prepare("SELECT version, createdBy FROM config_versions").all();
+    expect(versions.results).toHaveLength(1);
+    expect(versions.results[0]).toMatchObject({
+      version: 1,
+      createdBy: "dashboard",
+    });
+  });
+});

--- a/worker/test/auto-rule-engine.spec.ts
+++ b/worker/test/auto-rule-engine.spec.ts
@@ -226,7 +226,7 @@ describe("auto rule engine", () => {
     const db = env.AUDIT_DB!;
 
     await kv.put(
-      "RULE_CONFIG",
+      "RULE_CONFIG::123456789",
       JSON.stringify(
         createConfig({
           dryRun: true,
@@ -297,7 +297,7 @@ describe("auto rule engine", () => {
     expect(logs.results).toHaveLength(1);
     expect((logs.results[0] as { decision: string }).decision).toBe("WOULD_PAUSE");
 
-    const storedLogs = (await kv.get("RULE_LOGS", "text")) as string;
+    const storedLogs = (await kv.get("RULE_LOGS::123456789", "text")) as string;
     expect(storedLogs).toContain("WOULD_PAUSE");
   });
 
@@ -306,7 +306,7 @@ describe("auto rule engine", () => {
     const db = env.AUDIT_DB!;
 
     await kv.put(
-      "RULE_CONFIG",
+      "RULE_CONFIG::123456789",
       JSON.stringify(
         createConfig({
           dryRun: false,
@@ -384,7 +384,7 @@ describe("auto rule engine", () => {
     const kv = new FakeKVNamespace();
     const db = env.AUDIT_DB!;
 
-    await kv.put("RULE_CONFIG", JSON.stringify(createConfig()));
+    await kv.put("RULE_CONFIG::123456789", JSON.stringify(createConfig()));
     await kv.put("AUTOMATION_RUN_LOCK", JSON.stringify({ runId: "existing-run" }));
 
     const fetchMock = vi.fn();
@@ -408,7 +408,7 @@ describe("auto rule engine", () => {
     expect(logs.results).toHaveLength(1);
     expect((logs.results[0] as { decision: string }).decision).toBe("SKIPPED_LOCK");
 
-    const storedLogs = (await kv.get("RULE_LOGS", "text")) as string;
+    const storedLogs = (await kv.get("RULE_LOGS::123456789", "text")) as string;
     expect(storedLogs).toContain("SKIPPED_LOCK");
   });
 
@@ -417,7 +417,7 @@ describe("auto rule engine", () => {
     const db = env.AUDIT_DB!;
 
     await kv.put(
-      "RULE_CONFIG",
+      "RULE_CONFIG::123456789",
       JSON.stringify(
         createConfig({
           dryRun: false,
@@ -470,7 +470,7 @@ describe("auto rule engine", () => {
     expect((logs.results[0] as { source: string }).source).toBe("system");
     expect((logs.results[0] as { status: string }).status).toBe("failed");
 
-    const storedLogs = (await kv.get("RULE_LOGS", "text")) as string;
+    const storedLogs = (await kv.get("RULE_LOGS::123456789", "text")) as string;
     expect(storedLogs).toContain("AUTOMATION_RUN_FAILED");
   });
 
@@ -479,7 +479,7 @@ describe("auto rule engine", () => {
     const db = env.AUDIT_DB!;
 
     await kv.put(
-      "RULE_CONFIG",
+      "RULE_CONFIG::123456789",
       JSON.stringify(
         createConfig({
           dryRun: false,

--- a/worker/test/auto-rule-engine.spec.ts
+++ b/worker/test/auto-rule-engine.spec.ts
@@ -1,0 +1,666 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { evaluateCampaigns, executeCampaignActions } from "../src/auto-rule-engine";
+import worker from "../src/index";
+import type { CampaignDecisionRow, Env, RuleConfig } from "../src/types";
+
+declare module "cloudflare:test" {
+  interface ProvidedEnv extends Env {}
+}
+
+class FakeKVNamespace {
+  private readonly store = new Map<string, string>();
+
+  async get(key: string, type?: "text" | "json"): Promise<string | unknown | null> {
+    const value = this.store.get(key);
+    if (typeof value !== "string") {
+      return null;
+    }
+
+    if (type === "json") {
+      return JSON.parse(value) as unknown;
+    }
+
+    return value;
+  }
+
+  async put(key: string, value: string): Promise<void> {
+    this.store.set(key, value);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+}
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+function createConfig(overrides: Partial<RuleConfig> = {}): RuleConfig {
+  return {
+    enabled: true,
+    dryRun: true,
+    pauseThreshold: 170000,
+    pauseThreshold2: 200000,
+    resumeThreshold: 150000,
+    cooldownHours: 24,
+    maxActionsPerRun: 1,
+    maxActionsPerDay: 1,
+    allowlistCampaignIds: [],
+    excludeCampaignIds: [],
+    emergencyStop: false,
+    arming: {
+      status: "armed",
+      adAccountConfirmed: true,
+      recentDryRunRunId: "run_dry_1",
+      recentDryRunReviewedAt: "2026-05-01T00:00:00.000Z",
+      reviewedBy: "operator",
+      reliabilityScore: 0.9,
+      evidenceWindowDays: 3,
+    },
+    ...overrides,
+  };
+}
+
+function createEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    META_ACCESS_TOKEN: "meta-test-token",
+    META_ACCOUNT_ID: "123456789",
+    CONFIG_KV: (overrides.CONFIG_KV ?? new FakeKVNamespace()) as unknown as Env["CONFIG_KV"],
+    AUDIT_DB: overrides.AUDIT_DB,
+    FRONTEND_URL: "https://dashboard.example.com",
+    API_AUTH_TOKEN: "api-test-token",
+    ALLOW_LOCAL_DEV: "false",
+  };
+}
+
+describe("auto rule engine", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("returns decision, why, and evidence without mutating Meta during evaluation", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if ((init?.method ?? "GET") === "POST") {
+        throw new Error("evaluator must not mutate Meta");
+      }
+
+      if (url.includes("/campaigns?fields=id,name,status")) {
+        return jsonResponse({
+          data: [{ id: "camp_1", name: "Campaign 1", status: "ACTIVE" }],
+        });
+      }
+
+      if (url.includes("/insights?") && url.includes("date_preset=today") && url.includes("level=campaign")) {
+        return jsonResponse({
+          data: [
+            {
+              campaign_id: "camp_1",
+              campaign_name: "Campaign 1",
+              spend: "180000",
+              actions: [{ action_type: "omni_purchase", value: "0" }],
+            },
+          ],
+        });
+      }
+
+      if (url.includes("/insights?") && url.includes("time_range=") && url.includes("level=campaign")) {
+        return jsonResponse({
+          data: [
+            {
+              campaign_id: "camp_1",
+              campaign_name: "Campaign 1",
+              spend: "200000",
+              actions: [{ action_type: "omni_purchase", value: "0" }],
+            },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const rows = await evaluateCampaigns(
+      createEnv(),
+      createConfig({
+        dryRun: false,
+        allowlistCampaignIds: ["camp_1"],
+      })
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].decision).toBe("PAUSE");
+    expect(rows[0].why.length).toBeGreaterThan(0);
+    expect(rows[0].evidence.dryRun).toBe(false);
+    expect(rows[0].evidence.allowlisted).toBe(true);
+    expect(rows[0].campaignSnapshot.spendToday).toBe(180000);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls.every(([, init]) => (init?.method ?? "GET") === "GET")).toBe(true);
+  });
+
+  it("lets executor perform Meta mutations only for actionable decisions", async () => {
+    const fetchMock = vi.fn(async () => {
+      return jsonResponse({ data: { success: true } });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const row: CampaignDecisionRow = {
+      id: "camp_1",
+      name: "Campaign 1",
+      status: "ACTIVE",
+      decision: "PAUSE",
+      why: ["Spend is above threshold with 0 omni_purchase."],
+      evidence: {
+        spendToday: 180000,
+        purchasesToday: 0,
+        purchases3d: null,
+        purchaseMetric: "omni_purchase",
+        dataState: "complete",
+        dryRun: false,
+        cooldownHours: 24,
+        maxActionsPerRun: 1,
+        maxActionsPerDay: 1,
+        allowlisted: true,
+        excluded: false,
+        emergencyStop: false,
+        armingStatus: "armed",
+        reliabilityScore: 0.9,
+      },
+      blockers: [],
+      campaignSnapshot: {
+        id: "camp_1",
+        name: "Campaign 1",
+        status: "ACTIVE",
+        spendToday: 180000,
+        purchasesToday: 0,
+        purchases3d: null,
+        purchaseMetric: "omni_purchase",
+        hasPurchaseMetric: true,
+        dataState: "complete",
+      },
+      warnings: [],
+      error: null,
+      insights: {
+        spend: 180000,
+        purchases: 0,
+        purchaseMetric: "omni_purchase",
+        hasPurchaseMetric: true,
+        dataState: "complete",
+      },
+    };
+
+    const execution = await executeCampaignActions(createEnv(), [row]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, requestInit] = fetchMock.mock.calls[0] as unknown as [RequestInfo | URL, RequestInit | undefined];
+    expect(requestInit?.method).toBe("POST");
+    expect(execution.actions).toHaveLength(1);
+    expect(execution.actions[0].action).toBe("PAUSE");
+    expect(execution.logs).toHaveLength(1);
+    expect(execution.logs[0].status).toBe("applied");
+    expect(execution.logs[0].source).toBe("live");
+    expect(execution.campaignStateUpdates).toEqual([
+      expect.objectContaining({
+        campaignId: "camp_1",
+        lastDecision: "PAUSE",
+        lastAction: "PAUSE",
+        pausedByTool: true,
+      }),
+    ]);
+  });
+
+  it("runs scheduled flow in dry-run, writes audit rows to real D1, and skips Meta mutations", async () => {
+    const kv = new FakeKVNamespace();
+    const db = env.AUDIT_DB!;
+
+    await kv.put(
+      "RULE_CONFIG",
+      JSON.stringify(
+        createConfig({
+          dryRun: true,
+          allowlistCampaignIds: ["camp_1"],
+        })
+      )
+    );
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if ((init?.method ?? "GET") === "POST") {
+        throw new Error("dry-run must not mutate Meta");
+      }
+
+      if (url.includes("/campaigns?fields=id,name,status")) {
+        return jsonResponse({
+          data: [{ id: "camp_1", name: "Campaign 1", status: "ACTIVE" }],
+        });
+      }
+
+      if (url.includes("/insights?") && url.includes("date_preset=today") && url.includes("level=campaign")) {
+        return jsonResponse({
+          data: [
+            {
+              campaign_id: "camp_1",
+              campaign_name: "Campaign 1",
+              spend: "180000",
+              actions: [{ action_type: "omni_purchase", value: "0" }],
+            },
+          ],
+        });
+      }
+
+      if (url.includes("/insights?") && url.includes("time_range=") && url.includes("level=campaign")) {
+        return jsonResponse({
+          data: [
+            {
+              campaign_id: "camp_1",
+              campaign_name: "Campaign 1",
+              spend: "200000",
+              actions: [{ action_type: "omni_purchase", value: "0" }],
+            },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ctx = createExecutionContext();
+    await worker.scheduled(
+      {} as ScheduledController,
+      createEnv({ CONFIG_KV: kv as unknown as Env["CONFIG_KV"], AUDIT_DB: db }),
+      ctx
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(fetchMock.mock.calls.every(([, init]) => (init?.method ?? "GET") === "GET")).toBe(true);
+
+    const runs = await db.prepare("SELECT id, status FROM automation_runs").all();
+    const logs = await db.prepare("SELECT decision, source, status FROM action_logs").all();
+
+    expect(runs.results).toHaveLength(1);
+    expect((runs.results[0] as { status: string }).status).toBe("completed");
+    expect(logs.results).toHaveLength(1);
+    expect((logs.results[0] as { decision: string }).decision).toBe("WOULD_PAUSE");
+
+    const storedLogs = (await kv.get("RULE_LOGS", "text")) as string;
+    expect(storedLogs).toContain("WOULD_PAUSE");
+  });
+
+  it("persists campaign_states for live applied actions", async () => {
+    const kv = new FakeKVNamespace();
+    const db = env.AUDIT_DB!;
+
+    await kv.put(
+      "RULE_CONFIG",
+      JSON.stringify(
+        createConfig({
+          dryRun: false,
+          allowlistCampaignIds: ["camp_1"],
+        })
+      )
+    );
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.includes("/campaigns?fields=id,name,status")) {
+        return jsonResponse({
+          data: [{ id: "camp_1", name: "Campaign 1", status: "ACTIVE" }],
+        });
+      }
+
+      if (url.includes("/insights?") && url.includes("date_preset=today") && url.includes("level=campaign")) {
+        return jsonResponse({
+          data: [
+            {
+              campaign_id: "camp_1",
+              campaign_name: "Campaign 1",
+              spend: "180000",
+              actions: [{ action_type: "omni_purchase", value: "0" }],
+            },
+          ],
+        });
+      }
+
+      if (url.includes("/insights?") && url.includes("time_range=") && url.includes("level=campaign")) {
+        return jsonResponse({
+          data: [
+            {
+              campaign_id: "camp_1",
+              campaign_name: "Campaign 1",
+              spend: "200000",
+              actions: [{ action_type: "omni_purchase", value: "0" }],
+            },
+          ],
+        });
+      }
+
+      if ((init?.method ?? "GET") === "POST") {
+        return jsonResponse({ data: { success: true } });
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ctx = createExecutionContext();
+    await worker.scheduled(
+      {} as ScheduledController,
+      createEnv({ CONFIG_KV: kv as unknown as Env["CONFIG_KV"], AUDIT_DB: db }),
+      ctx
+    );
+    await waitOnExecutionContext(ctx);
+
+    const states = await db
+      .prepare("SELECT campaignId, lastDecision, lastAction, pausedByTool FROM campaign_states")
+      .all();
+
+    expect(states.results).toHaveLength(1);
+    expect(states.results[0]).toMatchObject({
+      campaignId: "camp_1",
+      lastDecision: "PAUSE",
+      lastAction: "PAUSE",
+      pausedByTool: 1,
+    });
+  });
+
+  it("skips overlapping scheduled runs behind lock and records audit trail in real D1", async () => {
+    const kv = new FakeKVNamespace();
+    const db = env.AUDIT_DB!;
+
+    await kv.put("RULE_CONFIG", JSON.stringify(createConfig()));
+    await kv.put("AUTOMATION_RUN_LOCK", JSON.stringify({ runId: "existing-run" }));
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ctx = createExecutionContext();
+    await worker.scheduled(
+      {} as ScheduledController,
+      createEnv({ CONFIG_KV: kv as unknown as Env["CONFIG_KV"], AUDIT_DB: db }),
+      ctx
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const runs = await db.prepare("SELECT status FROM automation_runs").all();
+    const logs = await db.prepare("SELECT decision FROM action_logs").all();
+
+    expect(runs.results).toHaveLength(1);
+    expect((runs.results[0] as { status: string }).status).toBe("skipped_overlap");
+    expect(logs.results).toHaveLength(1);
+    expect((logs.results[0] as { decision: string }).decision).toBe("SKIPPED_LOCK");
+
+    const storedLogs = (await kv.get("RULE_LOGS", "text")) as string;
+    expect(storedLogs).toContain("SKIPPED_LOCK");
+  });
+
+  it("fails closed and writes run-level error when global insights layer is unavailable", async () => {
+    const kv = new FakeKVNamespace();
+    const db = env.AUDIT_DB!;
+
+    await kv.put(
+      "RULE_CONFIG",
+      JSON.stringify(
+        createConfig({
+          dryRun: false,
+          allowlistCampaignIds: ["camp_1"],
+        })
+      )
+    );
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if ((init?.method ?? "GET") === "POST") {
+        throw new Error("live mutation must be blocked when insights fail closed");
+      }
+
+      if (url.includes("/campaigns?fields=id,name,status")) {
+        return jsonResponse({
+          data: [{ id: "camp_1", name: "Campaign 1", status: "ACTIVE" }],
+        });
+      }
+
+      if (url.includes("/insights?") && url.includes("date_preset=today") && url.includes("level=campaign")) {
+        throw new Error("Meta insights unavailable");
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ctx = createExecutionContext();
+    await worker.scheduled(
+      {} as ScheduledController,
+      createEnv({ CONFIG_KV: kv as unknown as Env["CONFIG_KV"], AUDIT_DB: db }),
+      ctx
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(fetchMock.mock.calls.every(([, init]) => (init?.method ?? "GET") === "GET")).toBe(true);
+
+    const runs = await db.prepare("SELECT status, errorJson FROM automation_runs").all();
+    const logs = await db.prepare("SELECT decision, status, source, payloadJson FROM action_logs").all();
+
+    expect(runs.results).toHaveLength(1);
+    expect((runs.results[0] as { status: string }).status).toBe("failed");
+    expect(String((runs.results[0] as { errorJson: string | null }).errorJson)).toContain("AUTOMATION_RUN_FAILED");
+
+    expect(logs.results).toHaveLength(1);
+    expect((logs.results[0] as { decision: string }).decision).toBe("ERROR");
+    expect((logs.results[0] as { source: string }).source).toBe("system");
+    expect((logs.results[0] as { status: string }).status).toBe("failed");
+
+    const storedLogs = (await kv.get("RULE_LOGS", "text")) as string;
+    expect(storedLogs).toContain("AUTOMATION_RUN_FAILED");
+  });
+
+  it("blocks all live mutations when joined campaign insight row is missing", async () => {
+    const kv = new FakeKVNamespace();
+    const db = env.AUDIT_DB!;
+
+    await kv.put(
+      "RULE_CONFIG",
+      JSON.stringify(
+        createConfig({
+          dryRun: false,
+          allowlistCampaignIds: ["camp_1"],
+        })
+      )
+    );
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if ((init?.method ?? "GET") === "POST") {
+        throw new Error("missing joined row must block all live mutations");
+      }
+
+      if (url.includes("/campaigns?fields=id,name,status")) {
+        return jsonResponse({
+          data: [{ id: "camp_1", name: "Campaign 1", status: "ACTIVE" }],
+        });
+      }
+
+      if (url.includes("/insights?") && url.includes("level=campaign")) {
+        return jsonResponse({
+          data: [],
+        });
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ctx = createExecutionContext();
+    await worker.scheduled(
+      {} as ScheduledController,
+      createEnv({ CONFIG_KV: kv as unknown as Env["CONFIG_KV"], AUDIT_DB: db }),
+      ctx
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(fetchMock.mock.calls.every(([, init]) => (init?.method ?? "GET") === "GET")).toBe(true);
+
+    const runs = await db.prepare("SELECT status, errorJson FROM automation_runs").all();
+    expect(runs.results).toHaveLength(1);
+    expect((runs.results[0] as { status: string }).status).toBe("failed");
+    expect(String((runs.results[0] as { errorJson: string | null }).errorJson)).toContain("AUTOMATION_RUN_FAILED");
+  });
+
+
+  it("requires tool-paused provenance before live resume", async () => {
+    const fetchMock = vi.fn(async () => {
+      return jsonResponse({ data: { success: true } });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const row: CampaignDecisionRow = {
+      id: "camp_paused",
+      name: "Paused Campaign",
+      status: "PAUSED",
+      decision: "RESUME",
+      why: ["Spend is below resume threshold with omni_purchase evidence."],
+      evidence: {
+        spendToday: 100,
+        purchasesToday: 1,
+        purchases3d: 3,
+        purchaseMetric: "omni_purchase",
+        dataState: "complete",
+        dryRun: false,
+        cooldownHours: 24,
+        maxActionsPerRun: 1,
+        maxActionsPerDay: 1,
+        allowlisted: true,
+        excluded: false,
+        emergencyStop: false,
+        armingStatus: "armed",
+        reliabilityScore: 0.9,
+      },
+      blockers: [],
+      campaignSnapshot: {
+        id: "camp_paused",
+        name: "Paused Campaign",
+        status: "PAUSED",
+        spendToday: 100,
+        purchasesToday: 1,
+        purchases3d: 3,
+        purchaseMetric: "omni_purchase",
+        hasPurchaseMetric: true,
+        dataState: "complete",
+      },
+      warnings: [],
+      error: null,
+      insights: {
+        spend: 100,
+        purchases: 1,
+        purchaseMetric: "omni_purchase",
+        hasPurchaseMetric: true,
+        dataState: "complete",
+      },
+    };
+
+    const execution = await executeCampaignActions(createEnv(), [row], { runId: "run-live-1" });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(execution.actions).toHaveLength(0);
+    expect(execution.logs).toHaveLength(1);
+    expect(execution.logs[0].status).toBe("skipped");
+    expect(execution.logs[0].decision).toBe("RESUME");
+    expect(execution.logs[0].blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "PROVENANCE_REQUIRED",
+        }),
+      ])
+    );
+  });
+
+  it("allows live resume when pausedByTool provenance exists", async () => {
+    const db = env.AUDIT_DB!;
+    await db
+      .prepare("INSERT INTO campaign_states (campaignId, lastDecision, lastAction, lastActionAt, lastRunId, pausedByTool) VALUES (?, ?, ?, ?, ?, ?)")
+      .bind("camp_paused", "PAUSE", "PAUSE", "2026-05-01T00:00:00.000Z", "run-previous", 1)
+      .run();
+
+    const fetchMock = vi.fn(async () => {
+      return jsonResponse({ data: { success: true } });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const row: CampaignDecisionRow = {
+      id: "camp_paused",
+      name: "Paused Campaign",
+      status: "PAUSED",
+      decision: "RESUME",
+      why: ["Spend is below resume threshold with omni_purchase evidence."],
+      evidence: {
+        spendToday: 100,
+        purchasesToday: 1,
+        purchases3d: 3,
+        purchaseMetric: "omni_purchase",
+        dataState: "complete",
+        dryRun: false,
+        cooldownHours: 24,
+        maxActionsPerRun: 1,
+        maxActionsPerDay: 1,
+        allowlisted: true,
+        excluded: false,
+        emergencyStop: false,
+        armingStatus: "armed",
+        reliabilityScore: 0.9,
+      },
+      blockers: [],
+      campaignSnapshot: {
+        id: "camp_paused",
+        name: "Paused Campaign",
+        status: "PAUSED",
+        spendToday: 100,
+        purchasesToday: 1,
+        purchases3d: 3,
+        purchaseMetric: "omni_purchase",
+        hasPurchaseMetric: true,
+        dataState: "complete",
+      },
+      warnings: [],
+      error: null,
+      insights: {
+        spend: 100,
+        purchases: 1,
+        purchaseMetric: "omni_purchase",
+        hasPurchaseMetric: true,
+        dataState: "complete",
+      },
+    };
+
+    const execution = await executeCampaignActions(createEnv({ AUDIT_DB: db }), [row], { runId: "run-live-2" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(execution.actions).toHaveLength(1);
+    expect(execution.actions[0].action).toBe("RESUME");
+    expect(execution.logs).toHaveLength(1);
+    expect(execution.logs[0].status).toBe("applied");
+  });
+});

--- a/worker/test/d1-migrations.ts
+++ b/worker/test/d1-migrations.ts
@@ -1,0 +1,52 @@
+export const migrations = [
+  {
+    name: "0001_audit_schema.sql",
+    queries: [
+      `CREATE TABLE IF NOT EXISTS config_versions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        version INTEGER NOT NULL,
+        configJson TEXT NOT NULL,
+        createdAt TEXT NOT NULL,
+        createdBy TEXT
+      )`,
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_config_versions_version
+        ON config_versions(version)`,
+      `CREATE TABLE IF NOT EXISTS automation_runs (
+        id TEXT PRIMARY KEY,
+        status TEXT NOT NULL,
+        startedAt TEXT NOT NULL,
+        completedAt TEXT,
+        failedAt TEXT,
+        summaryJson TEXT,
+        errorJson TEXT
+      )`,
+      `CREATE INDEX IF NOT EXISTS idx_automation_runs_status_started_at
+        ON automation_runs(status, startedAt DESC)`,
+      `CREATE TABLE IF NOT EXISTS campaign_states (
+        campaignId TEXT PRIMARY KEY,
+        lastDecision TEXT,
+        lastAction TEXT,
+        lastActionAt TEXT,
+        lastRunId TEXT,
+        pausedByTool INTEGER NOT NULL DEFAULT 0
+      )`,
+      `CREATE INDEX IF NOT EXISTS idx_campaign_states_last_run_id
+        ON campaign_states(lastRunId)`,
+      `CREATE TABLE IF NOT EXISTS action_logs (
+        id TEXT PRIMARY KEY,
+        runId TEXT NOT NULL,
+        campaignId TEXT,
+        decision TEXT NOT NULL,
+        source TEXT NOT NULL,
+        status TEXT NOT NULL,
+        occurredAt TEXT NOT NULL,
+        payloadJson TEXT NOT NULL,
+        FOREIGN KEY (runId) REFERENCES automation_runs(id)
+      )`,
+      `CREATE INDEX IF NOT EXISTS idx_action_logs_run_id_occurred_at
+        ON action_logs(runId, occurredAt DESC)`,
+      `CREATE INDEX IF NOT EXISTS idx_action_logs_campaign_id_occurred_at
+        ON action_logs(campaignId, occurredAt DESC)`,
+    ],
+  },
+];

--- a/worker/test/meta-api-client.spec.ts
+++ b/worker/test/meta-api-client.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { extractPurchaseCount, fetchActiveCampaigns, pauseCampaign, resumeCampaign } from "../src/meta-api-client";
+import { extractPurchaseCount, fetchActiveCampaigns, fetchAdAccounts, pauseCampaign, resumeCampaign } from "../src/meta-api-client";
 import type { Env } from "../src/types";
 
 function createEnv(): Env {
@@ -15,6 +15,33 @@ describe("meta api client auth", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it("fetches ad accounts with expected fields", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [{ id: "act_123", account_id: "123", name: "Main", account_status: 1 }],
+        }),
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      )
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const accounts = await fetchAdAccounts(createEnv());
+
+    expect(accounts).toEqual([{ id: "act_123", account_id: "123", name: "Main", account_status: 1 }]);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit | undefined];
+    expect(url).toBe("https://graph.facebook.com/v21.0/me/adaccounts?fields=id,account_id,name,account_status");
+    expect(init?.headers).toMatchObject({
+      Authorization: "Bearer meta-test-token",
+    });
   });
 
   it("uses Authorization Bearer header without access_token in URL for campaign fetch", async () => {
@@ -39,6 +66,23 @@ describe("meta api client auth", () => {
     expect(init?.headers).toMatchObject({
       Authorization: "Bearer meta-test-token",
     });
+  });
+
+  it("uses explicit account id for campaign fetch", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchActiveCampaigns(createEnv(), "987654321");
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit | undefined];
+    expect(url).toContain("https://graph.facebook.com/v21.0/act_987654321/campaigns");
   });
 
   it("loads all campaign pages from paging.next", async () => {

--- a/worker/test/meta-api-client.spec.ts
+++ b/worker/test/meta-api-client.spec.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { extractPurchaseCount, fetchActiveCampaigns, pauseCampaign, resumeCampaign } from "../src/meta-api-client";
+import type { Env } from "../src/types";
+
+function createEnv(): Env {
+  return {
+    META_ACCESS_TOKEN: "meta-test-token",
+    META_ACCOUNT_ID: "123456789",
+    CONFIG_KV: {} as Env["CONFIG_KV"],
+  };
+}
+
+describe("meta api client auth", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("uses Authorization Bearer header without access_token in URL for campaign fetch", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchActiveCampaigns(createEnv());
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit | undefined];
+
+    expect(url).toContain("https://graph.facebook.com/v21.0/act_123456789/campaigns");
+    expect(url).not.toContain("access_token=");
+    expect(init?.headers).toMatchObject({
+      Authorization: "Bearer meta-test-token",
+    });
+  });
+
+  it("loads all campaign pages from paging.next", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [{ id: "camp_1", name: "Campaign 1", status: "ACTIVE" }],
+            paging: {
+              next: "https://graph.facebook.com/v21.0/act_123456789/campaigns?after=cursor_1",
+            },
+          }),
+          {
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [{ id: "camp_2", name: "Campaign 2", status: "PAUSED" }],
+          }),
+          {
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        )
+      );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const campaigns = await fetchActiveCampaigns(createEnv());
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(campaigns).toEqual([
+      { id: "camp_1", name: "Campaign 1", status: "ACTIVE" },
+      { id: "camp_2", name: "Campaign 2", status: "PAUSED" },
+    ]);
+
+    const [firstUrl, firstInit] = fetchMock.mock.calls[0] as [string, RequestInit | undefined];
+    const [secondUrl, secondInit] = fetchMock.mock.calls[1] as [string, RequestInit | undefined];
+
+    expect(firstUrl).toContain("/campaigns");
+    expect(secondUrl).toContain("after=cursor_1");
+    expect(firstInit?.headers).toMatchObject({ Authorization: "Bearer meta-test-token" });
+    expect(secondInit?.headers).toMatchObject({ Authorization: "Bearer meta-test-token" });
+  });
+
+  it("counts omni_purchase when present", () => {
+    const purchases = extractPurchaseCount([
+      { action_type: "purchase", value: "9" },
+      { action_type: "omni_purchase", value: "2" },
+    ]);
+
+    expect(purchases).toBe(2);
+  });
+
+  it("does not fallback to purchase when omni_purchase is missing", () => {
+    const purchases = extractPurchaseCount([
+      { action_type: "purchase", value: "9" },
+    ]);
+
+    expect(purchases).toBe(0);
+  });
+
+  it("uses Authorization Bearer header without access_token in pause body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: { success: true } }), {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await pauseCampaign(createEnv(), "camp_1");
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit | undefined];
+    expect(url).toBe("https://graph.facebook.com/v21.0/camp_1");
+    expect(init?.headers).toMatchObject({
+      Authorization: "Bearer meta-test-token",
+      "Content-Type": "application/json",
+    });
+    expect(String(init?.body)).not.toContain("access_token");
+    expect(String(init?.body)).toContain('"status":"PAUSED"');
+  });
+
+  it("uses Authorization Bearer header without access_token in resume body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: { success: true } }), {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await resumeCampaign(createEnv(), "camp_2");
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit | undefined];
+    expect(url).toBe("https://graph.facebook.com/v21.0/camp_2");
+    expect(init?.headers).toMatchObject({
+      Authorization: "Bearer meta-test-token",
+      "Content-Type": "application/json",
+    });
+    expect(String(init?.body)).not.toContain("access_token");
+    expect(String(init?.body)).toContain('"status":"ACTIVE"');
+  });
+});

--- a/worker/test/setup.ts
+++ b/worker/test/setup.ts
@@ -1,0 +1,25 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeAll, beforeEach } from "vitest";
+
+import { migrations } from "./d1-migrations";
+
+beforeAll(async () => {
+  if (!env.AUDIT_DB) {
+    return;
+  }
+
+  await applyD1Migrations(env.AUDIT_DB, migrations);
+});
+
+beforeEach(async () => {
+  if (!env.AUDIT_DB) {
+    return;
+  }
+
+  await env.AUDIT_DB.exec(`
+    DELETE FROM action_logs;
+    DELETE FROM campaign_states;
+    DELETE FROM config_versions;
+    DELETE FROM automation_runs;
+  `);
+});

--- a/worker/test/tsconfig.json
+++ b/worker/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "Bundler",
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers"]
+  },
+  "include": ["./**/*.ts", "../vitest.config.ts"]
+}

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig({
+  test: {
+    include: ["test/**/*.spec.ts"],
+    setupFiles: ["./test/setup.ts"],
+    poolOptions: {
+      workers: {
+        wrangler: {
+          configPath: "./wrangler.jsonc",
+        },
+      },
+    },
+  },
+});

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -1,4 +1,5 @@
 {
+  "$schema": "node_modules/wrangler/config-schema.json",
   "name": "meta-ads-automation",
   "main": "src/index.ts",
   "compatibility_date": "2026-04-30",
@@ -9,6 +10,14 @@
     {
       "binding": "CONFIG_KV",
       "id": "placeholder_id"
+    }
+  ],
+  "d1_databases": [
+    {
+      "binding": "AUDIT_DB",
+      "database_name": "meta-ads-audit",
+      "database_id": "placeholder_audit_db_id",
+      "migrations_dir": "./migrations"
     }
   ],
   "vars": {

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -9,18 +9,19 @@
   "kv_namespaces": [
     {
       "binding": "CONFIG_KV",
-      "id": "placeholder_id"
+      "id": "032561124bfe42d6bcaa58b3bdd983a7"
     }
   ],
   "d1_databases": [
     {
       "binding": "AUDIT_DB",
       "database_name": "meta-ads-audit",
-      "database_id": "placeholder_audit_db_id",
+      "database_id": "b4bd5e78-a138-4d05-b7d5-e9b884d0c504",
       "migrations_dir": "./migrations"
     }
   ],
   "vars": {
-    "FRONTEND_URL": "https://meta-ads-dashboard.vercel.app"
+    "FRONTEND_URL": "https://meta-ads-dashboard.vercel.app",
+    "META_ACCOUNT_ID": "1069347140701722"
   }
 }


### PR DESCRIPTION
## Summary
- Add Phase B worker guardrails with KV observability and clearer run/action provenance signals.
- Isolate provenance-fail path to fail closed for unsafe live mutations while preserving auditability.
- Add D1 audit schema and coverage tests, plus a minimal frontend/worker pre-merge gate fix to keep CI green.

## Included commits
- fix(worker): harden KV/D1 failure handling in automation
- feat(worker): add phase B guardrails, audit schema, and tests
- test(worker): add shared vitest test scaffolding
- fix(frontend,worker): unblock pre-merge build gate and clean EOF formatting

## Test plan
- [x] npm --prefix worker test
- [x] npm --prefix frontend run build
- [ ] Staging smoke: GET /api/health
- [ ] Staging smoke: GET /api/campaigns
- [ ] Staging smoke: one scheduled/dry-run to verify log + audit flow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Phase B guardrails to the Cloudflare Worker with D1-backed audit logs, improved observability, and an account-scoped dashboard/API so campaign operations are isolated per ad account. Also adds a docs set for API, architecture, operations, and security, and keeps the pre-merge gate green.

- **New Features**
  - Guardrails and engine: split evaluate vs execute; fail-closed live path; stricter insights; per-campaign provenance; safer defaults.
  - Audit: D1 tables (`config_versions`, `automation_runs`, `campaign_states`, `action_logs`) with run/status tracking.
  - Observability and robustness: KV run logs, overlap run lock, richer health/config responses, and hardened KV/D1 failure handling.
  - Meta client: `Authorization` header (no `access_token` in URL), typed responses, ad-account listing, account-scoped insights.
  - Frontend/API: requires selecting an ad account; typed API envelope; TS deprecation flag keeps CI green.
  - Docs and tests: added `README.md`, `docs/API.md`, `docs/OPERATIONS.md`, `docs/SECURITY.md`, `ARCHITECTURE.md`, `CONTRIBUTING.md`; `vitest` suite with `@cloudflare/vitest-pool-workers` for auth, engine, and client coverage.

- **Migration**
  - Bind D1 as `AUDIT_DB` and run migrations from `worker/migrations`.
  - Configure KV `CONFIG_KV`; KV is used for run locks and logs.
  - Set `META_ACCOUNT_ID` and `FRONTEND_URL`; set API auth via `API_AUTH_TOKEN` or Cloudflare Access (`CLOUDFLARE_ACCESS_AUD`).
  - Deploy updated `worker/wrangler.jsonc` with the D1 binding and vars; no app code changes required.

<sup>Written for commit b3cef55d8606ebbb252e1ecb38656dd84c9c181c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Documentation

- `README.md`: added project overview, quick start, verification commands, documentation map, deployment shape, and current status.
- `ARCHITECTURE.md`: documented frontend/Worker runtime architecture, scheduled automation flow, KV/D1 persistence, rule model, live-mode gates, and API envelope.
- `CONTRIBUTING.md`: added contributor setup, local environment, smoke test, verification commands, workflow, and documentation expectations.
- `CONTEXT.md`: captured domain context for the account-scoped API, D1 audit model, strict `omni_purchase`, dry-run defaults, rollout gaps, and working conventions.
- `docs/API.md`: documented API auth, response envelopes, account-scoped routes, config validation, version conflicts, live-arm blocking, logs, and health behavior.
- `docs/OPERATIONS.md`: added runbook coverage for secrets, local development, D1 migrations, KV keys, deploy checks, emergency stop, live-mode readiness, and troubleshooting.
- `docs/SECURITY.md`: documented API auth paths, mutation origin guard, secrets handling, fail-closed data behavior, dry-run default, audit persistence, known gaps, and incident steps.
- `docs/adr/README.md`: added ADR location guidance and template.
- `frontend/README.md`: replaced the default Vite template with dashboard-specific development notes.
- `CLAUDE.md` and `AGENTS.md`: updated agent-facing instructions so future work starts from the current docs and architecture.
